### PR TITLE
Moving ui image to renga-ui and fixing corresponding doc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,7 +226,7 @@ services:
       API_URL: http://localhost/api/swagger.json
       OAUTH2_REDIRECT_URL: http://localhost/admin/swagger/oauth2-redirect.html
   ui:
-    image: ${IMAGE_REPOSITORY}renga-web-frontend:$PLATFORM_VERSION
+    image: ${IMAGE_REPOSITORY}renga-ui:$PLATFORM_VERSION
     ports:
       - 5000
     links:

--- a/docs/developer/code_repo_structure.rst
+++ b/docs/developer/code_repo_structure.rst
@@ -14,7 +14,7 @@ The **RENGA** project code structure is split into the following github reposito
 - renga-python_ - Python API & Command Line Interface (CLI)
 - renga-storage_ - Storage service
 - renga-tutorials_ - files for getting started application (TBD)
-- renga-web-frontend_ - web front-end interface
+- renga-ui_ - web front-end interface
 - renga_ - umbrella project, links to all other project
 
 .. _renga: https://github.com/SwissDataScienceCenter/renga
@@ -27,4 +27,4 @@ The **RENGA** project code structure is split into the following github reposito
 .. _renga-python: https://github.com/SwissDataScienceCenter/renga-python
 .. _renga-storage: https://github.com/SwissDataScienceCenter/renga-storage
 .. _renga-tutorials: https://github.com/SwissDataScienceCenter/renga-tutorials
-.. _renga-web-frontend: https://github.com/SwissDataScienceCenter/renga-web-frontend
+.. _renga-ui: https://github.com/SwissDataScienceCenter/renga-ui


### PR DESCRIPTION
Depends on:
- [x] https://github.com/SwissDataScienceCenter/renga-ui/pull/13
- [x] Updating docker hub