### PR TITLE
Added docker-compose as a prerequisite

### DIFF
--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -18,6 +18,7 @@ Prerequisites
 -------------
 
 * `Docker <http://www.docker.com>`_
+* `Docker Compose >=1.14 <https://docs.docker.com/compose/install/>`_ (**Linux Only**)
 * `GNU make <https://www.gnu.org/software/make/>`_
 * `sbt <http://www.scala-sbt.org/>`_
 


### PR DESCRIPTION
docker-compose is not installed with docker, unlike on mac.