### PR TITLE
Fix endpoints environment variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,12 +107,14 @@ docker-images: $(scala-services) $(dockerfile-services)
 # Platform actions
 .PHONY: start stop restart test
 start:
-	export RENGA_ENDPOINT=http://localhost
-	export RENGA_CONTAINERS_ENDPOINT=http://`docker network inspect bridge --format='{{(index (index .IPAM.Config) 0).Gateway}}'`
-	@docker-compose build
-	@docker-compose create
-	@docker-compose up -d
-	@./scripts/wait-for-services.sh
+ifeq ($(RENGA_ENDPOINT),)
+	RENGA_ENDPOINT="http://localhost" RENGA_CONTAINERS_ENDPOINTS=http://`docker network inspect bridge --format='{{(index (index .IPAM.Config) 0).Gateway}}'` $(MAKE) start
+else
+	docker-compose build
+	docker-compose create
+	docker-compose up -d
+	./scripts/wait-for-services.sh ;
+endif
 
 stop:
 	@docker-compose stop


### PR DESCRIPTION
Fix the environment variables RENGA_ENDPOINT and RENGA_CONTAINERS_ENDPOINT in the Makefile. We may need to use a similar approach in the stop target.
