### PR TITLE
docs reformatting

### DIFF
--- a/docs/_static/uml/multi_resource_example.uml
+++ b/docs/_static/uml/multi_resource_example.uml
@@ -1,0 +1,61 @@
+    @startuml
+
+    autonumber
+    hide footbox
+    skinparam shadowing false
+
+    participant Client
+    participant Deployer
+    participant Repository as Repo
+    participant "Resource\nManager" as RM
+    participant "Knowledge\nGraph" as KG
+
+    == Authorization ==
+    Client->Deployer: getDeployAuth
+    activate Deployer
+    Deployer->Repo: getRepoAuth
+    activate Repo
+    Repo-->Repo: get authorization\nfrom Resource Manager
+    activate Repo
+    deactivate Repo
+    Repo-->Deployer: repoAuth
+    deactivate Repo
+    Deployer->RM: getAuth
+    activate RM
+    RM->KG: getAttr
+    activate KG
+    KG-->RM: attributes
+    deactivate KG
+    RM-->RM: apply ABAC
+    activate RM
+    deactivate RM
+    RM-->Deployer: authorization
+    deactivate RM
+    Deployer->KG: recordDeployment
+    activate KG
+    KG-->Deployer: confirm
+    deactivate KG
+    Deployer-->Client: deployAuth
+    deactivate Deployer
+
+    == Deployment ==
+    Client->Deployer: deploy(deployAuth)
+    activate Deployer
+    Deployer-->Deployer: verify deployAuth
+    Deployer->Repo: getRepo
+    activate Repo
+    Repo-->Repo: pull from repository backend
+    activate Repo
+    deactivate Repo
+    Repo-->Deployer: repo
+    deactivate Repo
+    Deployer-->Deployer: build
+    activate Deployer
+    deactivate Deployer
+    Deployer-->Deployer: deploy
+    activate Deployer
+    deactivate Deployer
+    Deployer-->Client: deployment
+    deactivate Deployer
+
+    @enduml

--- a/docs/developer/general/json_web_tokens.rst
+++ b/docs/developer/general/json_web_tokens.rst
@@ -12,13 +12,28 @@ Relevant documentation
 ----------------------
 
 - `RFC7519 <https://tools.ietf.org/html/rfc7519>`_ JWT definition
-- `jwt.io <https://jwt.io>`_, auth0's site about JWTs. Useful for its online JWT parser and listing of JWT libraries.
-- `OpenID Connect Core <http://openid.net/specs/openid-connect-core-1_0.html>`_ Specification for the identity management
+
+- `jwt.io <https://jwt.io>`_, auth0's site about JWTs. Useful for its online
+  JWT parser  and listing of JWT libraries.
+
+- `OpenID Connect Core <http://openid.net/specs/openid-connect-core-
+  1_0.html>`_ Specification for the identity management
+
 - `RFC6749 <https://tools.ietf.org/html/rfc6749>`_ OAuth2
+
 - `RFC6750 <https://tools.ietf.org/html/rfc6750>`_ Bearer token specifics
-- `Keycloak documentation <https://keycloak.gitbooks.io>`_ Keycloak documentation.
-- `OIDC in Keycloak <https://keycloak.gitbooks.io/documentation/content/server_admin/topics/sso-protocols/oidc.html>`_ for a description of Keycloak's implementation of OpenID Connect.
-- `Auth0 articles <https://auth0.com/docs/apis>`_ describing their own services. Auth0 is a certified OIDC provider and their documentation is more accessible than the OIDC specification.
+
+- `Keycloak documentation <https://keycloak.gitbooks.io>`_ Keycloak
+  documentation.
+
+- `OIDC in Keycloak
+  <https://keycloak.gitbooks.io/documentation/content/server_admin/topics/sso-
+  protocols/oidc.html>`_ for a description of Keycloak's implementation of
+  OpenID Connect.
+
+- `Auth0 articles <https://auth0.com/docs/apis>`_ describing their own
+  services. Auth0 is a certified OIDC provider and their documentation is more
+  accessible than the OIDC specification.
 
 Introduction
 ------------
@@ -30,13 +45,18 @@ terms, a valid token holds the proof of the claims it contains.
 identity manager (keycloak) are used to prove:
 
 - the user id of its bearer (``sub`` claim)
-- the platform global access attributes associated with that user, coming both from what the user requested (consented scope) and what the identity manager granted (stored roles, and other global attributes)
+
+- the platform global access attributes associated with that user, coming both
+  from what the user requested (consented scope) and what the identity manager
+  granted (stored roles, and other global attributes)
 
 Any additional piece of information about identity must be recovered using
-OIDC `identity tokens <http://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken>`_
-and/or the `userinfo endpoint <http://openid.net/specs/openid-connect-core-1_0.html#UserInfo>`_.
+OIDC `identity tokens <http://openid.net/specs/openid-connect-core-
+1_0.html#CodeIDToken>`_ and/or the `userinfo endpoint <http://openid.net/specs
+/openid-connect-core-1_0.html#UserInfo>`_.
 
 Access Tokens from the resource manager (RM) are used to prove:
+
 - the user id of its bearer (``sub`` claim)
 - the access permissions granted by the RM on a particular request
 - the content of said request
@@ -50,13 +70,26 @@ authorization/blob/master/swagger.yml>`_.
 
 Notes on the request:
 
-- the subject of the access request is specified in the ``permission_holder_id`` field of the request body. Its absence is to be interpreted as a global access request (e.g. permission to create a bucket).
+- the subject of the access request is specified in the
+  ``permission_holder_id`` field of the request body. Its absence is to be
+  interpreted as a global access request (e.g. permission to create a bucket).
+
 - the access permissions requested are described in the ``scope`` field
-- the content of the request (provided by the requesting service) is held in ``permission_holder_id`` (main subject) and :code:`extra_claims` (detailed subject).
+
+- the content of the request (provided by the requesting service) is held in
+  ``permission_holder_id`` (main subject) and ``extra_claims`` (detailed
+  subject).
 
 Notes on the response:
 
-- the response is a json object containing a token in the ``access_token`` field
-- if a ``permission_holder_id`` was present, a :code:`resource_id` claim is present in the returned token
-- the ``resource_scope`` field holds the granted scope (i.e. permissions), which can be empty (no permission granted)
-- the optional ``resource_extras`` will contain a serialized json object of the same value as the incoming :code:`extra_claims`
+- the response is a json object containing a token in the ``access_token``
+  field
+
+- if a ``permission_holder_id`` was present, a ``resource_id`` claim is
+  present in the returned token
+
+- the ``resource_scope`` field holds the granted scope (i.e. permissions),
+  which can be empty (no permission granted)
+
+- the optional ``resource_extras`` will contain a serialized json object of
+  the same value as the incoming ``extra_claims``

--- a/docs/developer/general/policy_based_access_controls.rst
+++ b/docs/developer/general/policy_based_access_controls.rst
@@ -7,7 +7,8 @@ Policy Based Access Controls
 
 .. figure:: /_static/images/pbac_illustrated.svg
 
-    Elements of PBAC workflow as implemented in **Renga**: Policy Enforcement Point (PEP), Policy Decision Point (PDP), Policy Information Point (PIP).
+    Elements of PBAC workflow as implemented in **Renga**: Policy Enforcement
+    Point (PEP), Policy Decision Point (PDP), Policy Information Point (PIP).
 
 
 The *Policy Based Access Control* (`PBAC wiki <https://en.wikipedia.org/wiki
@@ -19,53 +20,54 @@ In the recommended architecture of the PBAC access control paradigm, the
 standard workflow is as follows:
 
 - The *Policy Enforcement Point* (PEP) is the client-facing service. It is
-  responsible for guarding the resource. When the PEP receives a request to access
-  a resource (1) it   inspects the request and combines it with other contextual
-  information to generate a authorization request to the *Policy Decision Point*
-  (PDP) (2). The PEP enforces the permissions granted   by the PDP and calls the
-  underlying API business logic to the protected resource backend only if the PDP
-  allows it (8,9,10).
+  responsible for guarding the resource. When the PEP receives a request to
+  access a resource (1) it inspects the request and combines it with other
+  contextual information to generate a authorization request to the *Policy
+  Decision Point* (PDP) (2). The PEP enforces the permissions granted by
+  the PDP and calls the underlying API business logic to the protected
+  resource backend only if the PDP allows it (8,9,10).
 
 - The *Policy Decision Point* (PDP) is the brain of the architecture. It
-  evaluates the authorization request with access control policies attached to the
-  targeted resource   retrieved from the *Policy Information Point* (PIP) (3,4)
-  and returns a permit-or-deny decision (5).
+  evaluates the authorization request with access control policies attached to
+  the targeted resource retrieved from the *Policy Information Point* (PIP)
+  (3,4) and returns a permit-or-deny decision (5).
 
 - The *Policy Information Point* bridges the PDP to a source of policies. This
   is where the policies are expressed. The expression allows things such as
-  allowing access   to a data set only if the data is requested by an authorized
+  allowing access to a data set only if the data is requested by an authorized
   (signed) application running on behalf of an authorized user, and on an
   authorized compute cluster.
 
 
-In **Renga** we altered the standard PBAC design to decompose the PEP component
-into an *authorization PEP* service and an *action PEP* service as illustrated
-in :numref:`fig-pbac_illustrated`. At the end of the action phase (6) the client
-receives from the *authorization PEP* a verifiable, expiring and unforgeable
-token that has all the information needed to access the resource. The client can
-subsequently use this authorization token for a limited period of time (few
-minutes) to claim the resource from the *action PEP* service (7-10).
+In **Renga** we altered the standard PBAC design to decompose the PEP
+component into an *authorization PEP* service and an *action PEP* service as
+illustrated in :numref:`fig-pbac_illustrated`. At the end of the action phase
+(6) the client receives from the *authorization PEP* a verifiable, expiring
+and unforgeable token that has all the information needed to access the
+resource. The client can subsequently use this authorization token for a
+limited period of time (few minutes) to claim the resource from the *action
+PEP* service (7-10).
 
 This decomposition into an authorization and action service has a number of
 advantages:
 
 - It allows the two services to reside on different servers, and it gives the
-  *authorization PEP*   an opportunity to route the request to the most
-  appropriate *action PEP*.   In a federated mode of operation this allows the
-  *authorization PEP* to redirect the request to the *authorization PEP* of the
-  organization   that owns the resource, and the latter can return a token with
-  its *action PEP* as the target. The redirect is transparent (but not
+  *authorization PEP* an opportunity to route the request to the most
+  appropriate *action PEP*. In a federated mode of operation this allows the
+  *authorization PEP* to redirect the request to the *authorization PEP* of
+  the organization that owns the resource, and the latter can return a token
+  with its *action PEP* as the target. The redirect is transparent (but not
   unknown) to the requesting client.
 
-- It allows the authorization request to be cascaded to multiple *authorization
-  PEPs* dependencies before acting on the response. It also gives the client an
-  opportunity to choose between several alternatives before making a decision.
-  This is particularly useful when accessing data that is mirrored in several
-  locations, each possibly governed by different permission policies, SLA   and
-  pricing models.
+- It allows the authorization request to be cascaded to multiple
+  *authorization PEPs* dependencies before acting on the response. It also
+  gives the client an opportunity to choose between several alternatives
+  before making a decision. This is particularly useful when accessing data
+  that is mirrored in several locations, each possibly governed by different
+  permission policies, SLA and pricing models.
 
 - The design allows for a parallel access to the resource, such as using the
-  same authorization token   for reading shards of the requested data from
+  same authorization token for reading shards of the requested data from
   different processes executing in parallel.
 
 In the **Renga** architecture, it is the :ref:`resource_manager` that fulfills
@@ -73,8 +75,6 @@ the role of the PDP. The PIP is served by the :ref:`knowledge_graph`. The PEP
 services are implemented by a number independent resource provider services,
 currently :ref:`storage` and :ref:`deployer`.
 
-In addition the resource backend is not directly accessible to the user. The PEP
-is an obligatory point of passage to the resource and it is thus here that the
-logic for updating the lineage in the knowledge graph is implemented (6a).
-
-
+In addition the resource backend is not directly accessible to the user. The
+PEP is an obligatory point of passage to the resource and it is thus here that
+the logic for updating the lineage in the knowledge graph is implemented (6a).

--- a/docs/developer/services/explorer_service.rst
+++ b/docs/developer/services/explorer_service.rst
@@ -3,11 +3,9 @@
 Explorer Service
 ================
 
-Contents
---------
-
-- :ref:`explorer_overview`
-- :ref:`explorer_endpoints`
+.. contents::
+    :depth: 1
+    :local:
 
 .. _explorer_overview:
 
@@ -27,45 +25,47 @@ The explorer API provides the following endpoints.
 
 **GET /storage/bucket**
 
-  ``controllers.StorageExplorerController.bucketList()``
+  ``StorageExplorerController.bucketList()``
 
   Retrieve all buckets
 
 **GET /storage/file/:id**
 
-  ``controllers.StorageExplorerController.fileMetadata(id: Long)``
+  ``StorageExplorerController.fileMetadata(id: Long)``
 
   Retrieve metadata of file with ``id``
 
 **GET /storage/bucket/:id/files**
 
-  ``controllers.StorageExplorerController.fileList(id: Long)``
+  ``StorageExplorerController.fileList(id: Long)``
 
   Retrieve a list of files in bucket with ``id``
 
 **GET /storage/bucket/:id**
 
-  ``controllers.StorageExplorerController.bucketMetadata(id: Long)``
+  ``StorageExplorerController.bucketMetadata(id: Long)``
 
   Retrieve metadata of bucket with ``id``
 
 **GET /storage/bucket/:id/files/*path**
 
-  ``controllers.StorageExplorerController.fileMetadatafromPath(id: Long, path: String)``
+  ``StorageExplorerController.fileMetadatafromPath(id: Long, path:
+  String)``
 
   Retrieve metadata of a file with ``path`` (filename) in bucket ``id``
 
 **GET /storage/file/:id/versions**
 
-  ``controllers.StorageExplorerController.retrievefileVersions( id: Long )``
+  ``StorageExplorerController.retrievefileVersions( id: Long )``
 
   Retrieve all versions of a file with ``id``; the query to find all instances
   of this filename is executed using the ``resource:version_of`` edge. The
-  :code:`file_version` resource vertices are returned.
+  ``file_version`` resource vertices are returned.
 
 **GET /storage/file/timestamps/:date1/:date2**
 
-  ``controllers.StorageExplorerController.retrieveFilesDate(date1: Long, date2: Long)``
+  ``StorageExplorerController.retrieveFilesDate(date1: Long,
+  date2: Long)``
 
   The timestamps are put on the resource:file_version nodes. This query
   retrieves all vertices with a timestamp between ``date1`` and ``date2``
@@ -73,7 +73,8 @@ The explorer API provides the following endpoints.
 
 **GET /storage**
 
-  ``controllers.StorageExplorerController.retrieveByUserName(userName: String)``
+  ``StorageExplorerController.retrieveByUserName(userName:
+  String)``
 
   Retrieve files with ``resource:owner == UserId``. Limited to 100 vertices by
   default.
@@ -81,50 +82,52 @@ The explorer API provides the following endpoints.
 
 **GET /graph/full**
 
-  ``controllers.GenericExplorerController.retrieveGraphSubset``
+  ``GenericExplorerController.retrieveGraphSubset``
 
   Get a limited amount of ``node->edge->node`` as ``[Seq[GraphSubSet]]``.
   Limited to 10 by default.
 
 **GET /graph/node/:id**
 
-  ``controllers.GenericExplorerController.retrieveNodeMetaData(id: Long)``
+  ``GenericExplorerController.retrieveNodeMetaData(id: Long)``
 
   Retrieve the metadata of a node with ``id``. Valid for all nodes.
 
 **GET /lineage/context/:id**
 
-  ``controllers.AnthologyExplorerController.lineageFromContext(id: Long)``
+  ``AnthologyExplorerController.lineageFromContext(id: Long)``
 
   Get the lineage starting from the context node with ``id``.
 
 **GET /lineage/file/:id**
 
-  ``controllers.LineageExplorerController.lineageFromFile(id: Long)``
+  ``LineageExplorerController.lineageFromFile(id: Long)``
 
   Get the lineage starting from a file node with ``id``.
 
 **GET /projects**
 
-  ``controllers.ProjectExplorerController.retrieveProjects``
+  ``ProjectExplorerController.retrieveProjects``
 
   Get the list with all projects in the graph. Limited to 100 by default.
 
 **GET /projects/user**
 
-  ``controllers.ProjectExplorerController.retrieveProjectByUserName(userId: Option[String] )``
+  ``ProjectExplorerController.retrieveProjectByUserName(userId:
+  Option[String] )``
 
   Get all projects of a user with ``userId`` given or else ``userId`` from
   request. Limited to 100 by default.
 
 **GET /projects/:id**
 
-  ``controllers.ProjectExplorerController.retrieveProjectMetadata( id: Long )``
+  ``ProjectExplorerController.retrieveProjectMetadata( id: Long
+  )``
 
   Get metadata for project node with ``id``.
 
 **GET /projects/:id/lineage**
 
-  ``controllers.ProjectExplorerController.retrieveProjectLineage(id: Long)``
+  ``ProjectExplorerController.retrieveProjectLineage(id: Long)``
 
   Get project lineage for project node with ``id``.

--- a/docs/developer/services/knowledge_graph.rst
+++ b/docs/developer/services/knowledge_graph.rst
@@ -3,36 +3,42 @@
 Knowledge Graph
 ===============
 
-Contents
---------
-
-- :ref:`Overview <kg_overview>`
-- :ref:`Introduction to Model <kg_introduction_to_model>`
-- :ref:`Model <kg_model>`
-- :ref:`Read <kg_read>`
-- :ref:`Update <kg_update>`
-- :ref:`Code Modules <kg_code_modules>`
+.. contents::
+    :depth: 1
+    :local:
 
 .. _kg_overview:
 
 Overview
 --------
 
-The knowledge graph service components manage the platform's global state. The knowledge graph establishes the relationship between users, data, algorithms, workflows, execution engines and other contextual information.
-It allows the lineage of a result to be traced back through the chain of operations to its original data. It does not store the content of the data sets, but references to the physical location of the content.
+The knowledge graph service components manage the platform's global state. The
+knowledge graph establishes the relationship between users, data, algorithms,
+workflows, execution engines and other contextual information. It allows the
+lineage of a result to be traced back through the chain of operations to its
+original data. It does not store the content of the data sets, but references
+to the physical location of the content.
 
-As shown in :numref:`fig-kg_architecture`, the knowledge graph is decomposed into separate parts:
+As shown in :numref:`fig-kg_architecture`, the knowledge graph is decomposed
+into separate parts:
 
-- :ref:`Model <kg_model>`: the global state of the platform. This global state is stored in the form of a knowledge graph.
+- :ref:`Model <kg_model>`: the global state of the platform. This global state
+  :is stored in the form of a knowledge graph.
 
-- :ref:`Read <kg_read>`: a way to read the state. This is (implicitly) provided by the direct read-only access of the graph by the
-  other platform services.
+- :ref:`Read <kg_read>`: a way to read the state. This is (implicitly)
+  provided by the direct read-only access of the graph by the   other platform
+  services.
 
-- :ref:`Update <kg_update>`: a way to update the global state. This is provided by the graph mutation service.
+- :ref:`Update <kg_update>`: a way to update the global state. This is
+  :provided by the graph mutation service.
 
-- Write Ahead Log (WAL): makes it possible to support archiving, point-in-time recovery, and roll-forward recovery to rebuild the graph database from the log in case of a failure.
+- Write Ahead Log (WAL): makes it possible to support archiving, point-in-time
+  recovery, and roll-forward recovery to rebuild the graph database from the
+  log in case of a failure.
 
-Read also: `The Elm Architecture <https://guide.elm-lang.org/architecture/>`_, `Redux, three principles <http://redux.js.org/docs/introduction/ThreePrinciples.html>`_.
+Read also: `The Elm Architecture <https://guide.elm-lang.org/architecture/>`_,
+`Redux, three principles
+<http://redux.js.org/docs/introduction/ThreePrinciples.html>`_.
 
 .. _fig-kg_architecture:
 
@@ -45,10 +51,16 @@ Read also: `The Elm Architecture <https://guide.elm-lang.org/architecture/>`_, `
 Introduction to Model
 ---------------------
 
-The knowledge graph is based on the Apache `TinkerPop3 <http://tinkerpop.apache.org/docs/current/reference/>`_ framework,
-with `Janusgraph <http://docs.janusgraph.org/latest/>`_ powering the graph database.
+The knowledge graph is based on the Apache `TinkerPop3
+<http://tinkerpop.apache.org/docs/current/reference/>`_ framework, with
+`Janusgraph <http://docs.janusgraph.org/latest/>`_ powering the graph
+database.
 
-As such, the knowledge graph is a property graph, leading to an intuitive way of modeling the state of the platform. First time readers should focus on understanding the concepts described in `this section <http://tinkerpop.apache.org/docs/current/reference/#vertex-properties>`_ of the tinkerpop documentation.
+As such, the knowledge graph is a property graph, leading to an intuitive way
+of modeling the state of the platform. First time readers should focus on
+understanding the concepts described in `this section
+<http://tinkerpop.apache.org/docs/current/reference/#vertex-properties>`_ of
+the tinkerpop documentation.
 
 .. _fig-tinkerpop-model:
 
@@ -62,12 +74,16 @@ As such, the knowledge graph is a property graph, leading to an intuitive way of
 Model
 -----
 
-The concepts coming from TinkerPop are extended in the knowledge graph by the addition of a graph type system.
-The purpose of the type system is to prevent inconsistent data to be written to the graph (e.g. a file must always have a file name).
+The concepts coming from TinkerPop are extended in the knowledge graph by the
+addition of a graph type system. The purpose of the type system is to prevent
+inconsistent data to be written to the graph (e.g. a file must always have a
+file name).
 
 Type system
 ^^^^^^^^^^^
-The type system leverages Janusgraph's graph `schema capabilities <http://docs.janusgraph.org/latest/schema.html>`_.
+
+The type system leverages Janusgraph's graph `schema capabilities
+<http://docs.janusgraph.org/latest/schema.html>`_.
 
 The type system restricts data types to the following subset:
 
@@ -102,51 +118,77 @@ also deactivated to strictly enforce data typing.
 
 Property keys are separated into two categories:
 
-- system property keys, which have a global interpretation (e.g the `type` property)
+- system property keys, which have a global interpretation (e.g the `type`
+  property)
+
 - (regular) property keys, which are directly manipulated
 
 To avoid name clashing, all non-system property keys must follow the pattern
-``<namespace>:<name>``, where namespace and name respectively adhere to the regular expressions
-``[-A-Za-z0-9_/.]*`` and ``[-A-Za-z0-9_/.]+``. This naming convention is also used with edge labels
-and named types.
+``<namespace>:<name>``, where namespace and name respectively adhere to the
+regular expressions ``[-A-Za-z0-9_/.]*`` and ``[-A-Za-z0-9_/.]+``. This naming
+convention is also used with edge labels and named types.
 
-Named types are used to provide data consistency checks on graph vertices, and are not applicable to edges
-nor vertex properties (seen as objects).
-They consist of:
+Named types are used to provide data consistency checks on graph vertices, and
+are not applicable to edges nor vertex properties (seen as objects). They
+consist of:
 
 - a name, which follows the ``<namespace>:<name>`` pattern
-- a set of supertypes, consisting of a set of ``<namespace>:<name>`` values (names)
-- a set of property keys, consisting of a set of ``<namespace>:<name>`` values (property keys)
+
+- a set of supertypes, consisting of a set of ``<namespace>:<name>`` values
+  (names)
+
+- a set of property keys, consisting of a set of ``<namespace>:<name>`` values
+  (property keys)
 
 Examples:
 
-1. ``name = "geom:point2d"``, :code:`supertypes = {}`, :code:`properties = { "geom:x", "geom:y" }`
-   Here, if a vertex ``v`` is know to be of type :code:`geom:point2d`, then we know that v has
-   ``geom:x`` and :code:`geom:y` properties.
-2. ``name = "geom:labeledPoint2d"``, :code:`supertypes = { "geom:point2d" }`,
-   ``properties = { "geom:x", "geom:y", "geom:label" }``
-   Here, if a vertex ``v`` is know to be of type :code:`geom:labeledPoint2d`, then as :code:`geom:point2d` is a supertype of
-   ``geom:labeledPoint2d``, :code:`v` is also of type :code:`geom:point2d`.
-   Notice also that the properties of ``geom:labeledPoint2d`` are a superset of the properties of type :code:`geom:point2d`.
+::
 
-The type system is initialized with the system property keys, (regular) property keys, edge labels and
-named types present in the type_init.json_ file.
+  name = "geom:point2d"
+  supertypes = {}
+  properties = {"geom:x", "geom:y" }
 
-The type system concepts are implemented in the graph-core_ module, see package `ch.datascience.graph.types`_.
+Here, if a vertex ``v`` is known to be of type ``geom:point2d``, then we know
+that ``v`` has ``geom:x`` and ``geom:y`` properties.
+
+::
+
+  name = "geom:labeledPoint2d"
+  supertypes = {"geom:point2d"}
+  properties = {"geom:x", "geom:y", "geom:label"}
+
+Here, if a vertex ``v`` is known to be of type ``geom:labeledPoint2d``, then
+as ``geom:point2d`` is a supertype of ``geom:labeledPoint2d``, ``v`` is also
+of type ``geom:point2d``. Notice also that the properties of
+``geom:labeledPoint2d`` are a superset of the properties of type
+``geom:point2d``.
+
+The type system is initialized with the system property keys, (regular)
+property keys, edge labels and named types present in the type_init.json_
+file.
+
+The type system concepts are implemented in the graph-core_ module, see
+package `ch.datascience.graph.types`_.
 
 .. _kg_read:
 
 Read
 ----
 
-Trusted platform services can use one the `gremlin variants <http://tinkerpop.apache.org/docs/current/reference/#gremlin-variants>`_ to read data from the graph.
-The graph traversals must be generated with a graph traversal source marked with the `ReadOnlyStrategy <http://tinkerpop.apache.org/docs/current/reference/#_readonlystrategy>`_.
+Trusted platform services can use one the `gremlin variants
+<http://tinkerpop.apache.org/docs/current/reference/#gremlin-variants>`_ to
+read data from the graph. The graph traversals must be generated with a graph
+traversal source marked with the `ReadOnlyStrategy
+<http://tinkerpop.apache.org/docs/current/reference/#_readonlystrategy>`_.
 
-If vertices or edges are extracted using a graph traversal, it may be desirable to perform the following:
+If vertices or edges are extracted using a graph traversal, it may be
+desirable to perform the following:
 
 - discard properties that do not follow the ``<namespace>:<name>`` pattern
-- in the case of vertices, transform the values from the ``type`` system property into named type constructs
-  (by mapping names to the named type construct they are associated with)
+
+- in the case of vertices, transform the values from the ``type`` system
+  property into named type constructs   (by mapping names to the named type
+  construct they are associated with)
 
 These steps are implemented in the VertexReader_ and the EdgeReader_ classes.
 
@@ -155,19 +197,28 @@ These steps are implemented in the VertexReader_ and the EdgeReader_ classes.
 Update
 ------
 
-In a similar fashion as in `the Elm architecture <https://guide.elm-lang.org/architecture/>`_, services
-need to send mutation requests to the graph mutation service when they need to update the knowledge graph.
+In a similar fashion as in `the Elm architecture <https://guide.elm-
+lang.org/architecture/>`_, services need to send mutation requests to the
+graph mutation service when they need to update the knowledge graph.
 
-A mutation request consists of a sequence of operations. The whole sequence of operations is processed
-in a single transaction, i.e. mutations are atomic with respect to transaction atomicity.
-Currently, there are four supported operations:
+A mutation request consists of a sequence of operations. The whole sequence of
+operations is processed in a single transaction, i.e. mutations are atomic
+with respect to transaction atomicity. Currently, there are four supported
+operations:
 
 - ``create_vertex``, create a new vertex in the graph
-- ``create_edge``, create a new edge in the graph
-- ``create_vertex_property``, add a (property key, value) pairing to a given vertex
-- ``update_vertex_property``, modify a vertex property. This is done by first removing the old (property key, value) pairing and then adding the (property key, new value) pairing
 
-The full definition of the graph mutation API resides in the `mutation API spec`_ file.
+- ``create_edge``, create a new edge in the graph
+
+- ``create_vertex_property``, add a (property key, value) pairing to a given
+  vertex
+
+- ``update_vertex_property``, modify a vertex property. This is done by first
+  removing the old (property key, value) pairing and then adding the (property
+  key, new value) pairing
+
+The full definition of the graph mutation API resides in the `mutation API
+spec`_ file.
 
 .. _fig-kg_mutation_seqdiag:
 
@@ -177,20 +228,27 @@ The full definition of the graph mutation API resides in the `mutation API spec`
 Detail of messages:
 
 1. client sends a mutation request as described above
-2. mutation service sends back an acknowledgment message containing the request and its assigned **uuid**
-3. client requests status of mutation identified by **uuid** received at (2 request received)
+
+2. mutation service sends back an acknowledgment message containing the
+request and its assigned **uuid**
+
+3. client requests status of mutation identified by **uuid** received at (2
+request received)
+
 4. mutation service sends back the mutation status
 
-The response sent at (4 mutation status) will contain a ``status`` field which can have two values:
+The response sent at (4 mutation status) will contain a ``status`` field which
+can have two values:
 
 - pending: the mutation has not been processed yet
 - completed: the mutation has been processed
 
-In the case of ``completed`` status, the response will contain more information about the result of
-processing the mutation.
-Notably, the response will display an error message if for some reason (e.g. invalid mutation), the mutation failed.
-Otherwise, if the mutation was successfully processed, then the response will contain a sequence of graph
-identifiers mapped from the incoming mutation request.
+In the case of ``completed`` status, the response will contain more
+information about the result of processing the mutation. Notably, the response
+will display an error message if for some reason (e.g. invalid mutation), the
+mutation failed. Otherwise, if the mutation was successfully processed, then
+the response will contain a sequence of graph identifiers mapped from the
+incoming mutation request.
 
 .. tabularcolumns:: |l|l|
 
@@ -214,9 +272,11 @@ Then, the response will contain::
 
     "results": [ { "id": 1234, "id": "1234->5678" } ]
 
-where ``1234`` is a vertex identifier and :code:`1234->5678` is an edge identifier.
+where ``1234`` is a vertex identifier and ``1234->5678`` is an edge
+identifier.
 
-Note that the resulting ids follow the same order as the order of operations in the request.
+Note that the resulting ids follow the same order as the order of operations
+in the request.
 
 .. _kg_code_modules:
 
@@ -226,7 +286,8 @@ Code Modules
 - graph-core_ - contains definitions for graph elements, typing, etc.
 - graph-typesystem_ - contains the graph typesystem management
 - graph-mutation_ - contains the graph mutation service
-- graph-init_ - contains the code used to initialize the graph type system with definitions in type_init.json_
+- graph-init_ - contains the code used to initialize the graph type system
+  with definitions in type_init.json_
 - graph-navigation_ - contains code to read the graph without a gremlin-shell
 
 .. _graph-core: https://github.com/SwissDataScienceCenter/renga-graph/tree/master/core

--- a/docs/developer/services/projects_service.rst
+++ b/docs/developer/services/projects_service.rst
@@ -3,14 +3,13 @@
 Projects Service
 ================
 
-Contents
---------
+.. contents::
+    :depth: 1
+    :local:
 
-- :ref:`Projects Data Model<projects_model>`
-- :ref:`Projects endpoints<projects_endpoints>`
-
-The projects service exposes a lightweight abstraction used to group other resources together
-(deployment contexts, deployment executions, storage buckets, storage files, ...).
+The projects service exposes a lightweight abstraction used to group other
+resources together (deployment contexts, deployment executions, storage
+buckets, storage files, ...).
 
 .. _projects_model:
 
@@ -20,8 +19,9 @@ Projects Data Model
 Project
 ^^^^^^^
 
-Projects within the Renga platform are given a unique identifier that should be used when manipulating them.
-In addition, a project will have the following attributes:
+Projects within the Renga platform are given a unique identifier that should
+be used when manipulating them. In addition, a project will have the following
+attributes:
 
 * a project name, keyed with ``project:project_name``.
 * a set of owners, keyed with ``resource:owner``.
@@ -30,7 +30,8 @@ In addition, a project will have the following attributes:
 Children Resources
 ^^^^^^^^^^^^^^^^^^
 
-Resources created within a given project will be linked to in the knowledge graph with ``project:is_part_of`` edges.
+Resources created within a given project will be linked to in the knowledge
+graph with ``project:is_part_of`` edges.
 
 See :ref:`here for an example involving storage resources<kg_data>`.
 
@@ -53,4 +54,5 @@ The projects API provides the following endpoints (`projects API spec`_).
 
 **POST /**
 
-  Create a project by supplying a name (mapped to ``project:project_name``) and optional labels (mapped to :code:`annotation:label`).
+  Create a project by supplying a name (mapped to ``project:project_name``)
+  and optional labels (mapped to ``annotation:label``).

--- a/docs/developer/services/resource_manager_service.rst
+++ b/docs/developer/services/resource_manager_service.rst
@@ -3,34 +3,27 @@
 Resource Manager Service
 ========================
 
-Contents
---------
-
-- :ref:`rm-overview`
-- :ref:`Authorization Flow <rm-authorization_flow>`
-- :ref:`Attributes <rm-attributes>`
-- :ref:`Rules <rm-rules>`
-- :ref:`Response from the RM <rm-response>`
-- :ref:`Accessing multiple resources and encapsulation <rm-encapsulation>`
-
-.. _rm-overview:
+.. contents::
+    :depth: 1
+    :local:
 
 Overview
 --------
 
-The resource manager (RM) service is responsible for authorizing access requests to resources described in the
-:ref:`knowledge_graph`.
-The role of the RM is to apply Policy-Based Access Control (:ref:`PBAC <policy_based_access_controls>`) rules to grant or reject access to resources.
+The resource manager (RM) service is responsible for authorizing access
+requests to resources described in the :ref:`knowledge_graph`. The role of the
+RM is to apply Policy-Based Access Control (:ref:`PBAC
+<policy_based_access_controls>`) rules to grant or reject access to resources.
 
 .. _rm-authorization_flow:
 
 Authorization Flow
 ------------------
 
-Whenever a user calls one of the platform services, said service may request access
-to resources on behalf of the user.
-The same applies in the case of an application performing a request (e.g. read a file); the service
-will request access to the resource on behalf of the user who launched that application.
+Whenever a user calls one of the platform services, said service may request
+access to resources on behalf of the user. The same applies in the case of an
+application performing a request (e.g. read a file); the service will request
+access to the resource on behalf of the user who launched that application.
 
 .. _fig-resource_manager_api:
 
@@ -55,18 +48,29 @@ Attributes
 
 The attributes used by the RM come from these sources:
 
-1. the request itself - contains the id of the accessed resource (optional) and the requested permissions
-2. the request context - extracted from the access token included in the HTTP headers
-3. the knowledge graph - in general, these are metadata fetched using the id of the requested resource
+1. the request itself - contains the id of the accessed resource (optional)
+and the requested permissions
+
+2. the request context - extracted from the access token included in the HTTP
+headers
+
+3. the knowledge graph - in general, these are metadata fetched using the id
+of the requested resource
 
 From the request
 ^^^^^^^^^^^^^^^^
 
 The request body contains:
 
-- the subject of the access request is specified in the ``resource_id`` field of the request body. Its absence is to be interpreted as a global access request (e.g. permission to create a bucket).
+- the subject of the access request is specified in the ``resource_id`` field
+  of the request body. Its absence is to be interpreted as a global access
+  request (e.g. permission to create a bucket).
+
 - the access permissions requested are described in the ``scope`` field
-- the content of the request (provided by the requesting service) is held in ``resource_id`` (main subject) and :code:`service_claims` (detailed subject).
+
+- the content of the request (provided by the requesting service) is held in
+  ``resource_id`` (main subject) and ``service_claims`` (detailed
+  subject).
 
 From the context
 ^^^^^^^^^^^^^^^^
@@ -74,16 +78,22 @@ From the context
 The access token contains:
 
 - the user who is requesting access, in the ``sub`` claim
-- attributes about the user (Note: need to configure roles, etc. from keycloak for this)
-- if the request comes from a deployed application, the id representing that application in the knowledge graph. Note: as we do not generate tokens inserted in deployed containers as of today, this attribute is not handed to the RM.
+
+- attributes about the user (Note: need to configure roles, etc. from keycloak
+  or this)
+
+- if the request comes from a deployed application, the id representing that
+  application in the knowledge graph. Note: as we do not generate tokens
+  inserted in deployed containers as of today, this attribute is not handed to
+  the RM.
 
 From the knowledge graph
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-If a ``resource_id`` was specified in the request, then the RM will fetch the corresponding
-vertex from the knowledge graph.
-Note: It is planned to allow more complex data to be retrieved, but a specific graph ontology needs to
-be defined first (``authorization:extends`` edge label for instance).
+If a ``resource_id`` was specified in the request, then the RM will fetch the
+corresponding vertex from the knowledge graph. Note: It is planned to allow
+more complex data to be retrieved, but a specific graph ontology needs to be
+defined first (``authorization:extends`` edge label for instance).
 
 .. _rm-rules:
 
@@ -92,46 +102,61 @@ Rules
 
 No rule framework devised as of today.
 
-This implies that the RM will allow access to any resource, provided that it exists and the request is valid.
+This implies that the RM will allow access to any resource, provided that it
+exists and the request is valid.
 
 .. _rm-response:
 
 Response from the RM
 --------------------
 
-- the response is a json object containing a token at the ``access_token`` field
-- if a ``https://rm.datascience.ch/resource_id`` was present, a :code:`resource_id` claim is present in the returned token
-- the ``https://rm.datascience.ch/scope`` field holds the granted scope (i.e. permissions), which can be empty (no permission granted)
-- the optional ``https://rm.datascience.ch/service_claims`` will contain a serialized json object of the same value as the incoming :code:`service_claims`
+- the response is a json object containing a token at the ``access_token``
+  field
+
+- if a ``https://rm.datascience.ch/resource_id`` was present, a
+  ``resource_id`` claim is present in the returned token
+
+- the ``https://rm.datascience.ch/scope`` field holds the granted scope (i.e.
+  permissions), which can be empty (no permission granted)
+
+- the optional ``https://rm.datascience.ch/service_claims`` will contain a
+  serialized  json object of the same value as the incoming
+  ``service_claims``
 
 .. _rm-encapsulation:
 
 Accessing multiple resources and encapsulation
 ----------------------------------------------
 
-In some cases, a service may need to request access to multiple resources to fulfill the client request.
+In some cases, a service may need to request access to multiple resources to
+fulfill the client request.
 
-One such example could be when a client wants to create a deployment using a code repository.
-There, the service which will create this deployment will need to ask for the right to create
-a deployment and for the right to read/clone the code.
+One such example could be when a client wants to create a deployment using a
+code repository. There, the service which will create this deployment will
+need to ask for the right to create a deployment and for the right to
+read/clone the code.
 
-When these cases are brought up with the need to split the interface into an authorization call
-followed by an action call (e.g. storage auth then io, or deployment auth then deploy),
-a good practice is to use authorization token encapsulation.
+When these cases are brought up with the need to split the interface into an
+authorization call followed by an action call (e.g. storage auth then io, or
+deployment auth then deploy), a good practice is to use authorization token
+encapsulation.
 
-Token encapsulation consists of first asking for authorization on all sub-resources,
-then encapsulate all authorization tokens into the main authorization call on the Resource Manager.
-The tokens are simply passed around in the ``service_claims`` field and will come back intact in the :code:`https://rm.datascience.ch/service_claims` claim.
+Token encapsulation consists of first asking for authorization on all sub-
+resources, then encapsulate all authorization tokens into the main
+authorization call on the Resource Manager. The tokens are simply passed
+around in the ``service_claims`` field and will come back intact in the
+``https://rm.datascience.ch/service_claims`` claim.
 
 Example:
 
 .. _fig-local_deployment:
 
-.. uml:: ../../_static/uml/local_deployment.sequence.uml
+.. uml:: ../../_static/uml/multi_resource_example.uml
    :alt: Sequence diagram of local application deployment.
 
 
-Message 5 ``getAuth`` contains the authorization token from response 4 :code:`repoAuth` in the :code:`repo_auth_token` field as shown below:
+Message 5 ``getAuth`` contains the authorization token from response 4
+``repoAuth`` in the ``repo_auth_token`` field as shown below:
 
 .. highlight:: json
 
@@ -149,10 +174,10 @@ Message 5 ``getAuth`` contains the authorization token from response 4 :code:`re
 
 
 
-During the action call, the service can now parse and verify the authorization token to process
-the request.
-When other resources need to be accessed (e.g. code during deploy), the service can simply call
-the action on the corresponding service using the proper token extracted from the
+During the action call, the service can now parse and verify the authorization
+token to process the request. When other resources need to be accessed (e.g.
+code during deploy, step 15), the service can simply call the action on the
+corresponding service using the proper token extracted from the
 ``https://rm.datascience.ch/service_claims`` claim of the encapsulating token.
 
 .. highlight:: python

--- a/docs/developer/services/services_architecture.rst
+++ b/docs/developer/services/services_architecture.rst
@@ -3,7 +3,12 @@
 Renga Architecture
 ==================
 
-This document describes the architecture of the (web) services that are part of the **Renga** platform.
+This document describes the architecture of the (web) services that are part
+of the **Renga** platform.
+
+.. contents::
+    :depth: 1
+    :local:
 
 .. _fig-architecture:
 
@@ -11,26 +16,36 @@ This document describes the architecture of the (web) services that are part of 
 
    -- Service Architecture
 
-As depicted in :numref:`fig-architecture`, **Renga** operates as a middleware that sits between applications, backend computing, and storage services.
-Applications interact with the platform services via client application programming interfaces.
-The interfaces are packaged as a collection of Software Development Kits (SDK) adapted to support a variety of programming languages and domain-specific environments.
-In the backend, connector services provide homogeneous interfaces to expose the various resource provider services.
+As depicted in :numref:`fig-architecture`, **Renga** operates as a middleware
+that sits between applications, backend computing, and storage services.
+Applications interact with the platform services via client application
+programming interfaces. The interfaces are packaged as a collection of
+Software Development Kits (SDK) adapted to support a variety of programming
+languages and domain-specific environments. In the backend, connector services
+provide homogeneous interfaces to expose the various resource provider
+services.
 
-Broadly speaking, the platform services allow users to perform various actions (read/write files, execute code, etc.) which
-are then described in the knowledge graph.
-The system intercepts, authorizes and logs resource access transactions into the knowledge graph.
-The event log can be consulted by the user and by other system services to search, retrieve the lineage information and reenact previously executed data processing chains.
+Broadly speaking, the platform services allow users to perform various actions
+(read/write files, execute code, etc.) which are then described in the
+knowledge graph. The system intercepts, authorizes and logs resource access
+transactions into the knowledge graph. The event log can be consulted by the
+user and by other system services to search, retrieve the lineage information
+and reenact previously executed data processing chains.
 
-The platform consists of loosely coupled services operating in a micro-services architecture style using the `Play framework <https://www.playframework.com/>`_.
-It is based on stateless HTTP objects that respond to standard HTTP methods.
-The technology used is JSON on REST/HTTP. It is implemented in Scala and Python, and runs on Docker containers in the cloud.
-Because of the micro-service architecture it is by definition modular, and therefore should be able to accommodate other languages or implementations used for individual components.
+The platform consists of loosely coupled services operating in a micro-
+services architecture style using the `Play framework
+<https://www.playframework.com/>`_. It is based on stateless HTTP objects that
+respond to standard HTTP methods. The technology used is JSON on REST/HTTP. It
+is implemented in Scala and Python, and runs on Docker containers in the
+cloud. Because of the micro-service architecture it is by definition modular,
+and therefore should be able to accommodate other languages or implementations
+used for individual components.
 
 Important Concepts
 ------------------
 
-Before delving into the details of the architecture components it is strongly advised to first get familiarized
-with a few foundational concepts:
+Before delving into the details of the architecture components it is strongly
+advised to first get familiarized with a few foundational concepts:
 
 .. toctree::
    :hidden:
@@ -45,13 +60,15 @@ with a few foundational concepts:
 Components
 ----------
 
-Details about the main service components of the architecture can be found here:
+Details about the main service components of the architecture can be found
+here:
 
 - Identity Manager (IM), provides user authentication
 - :ref:`resource_manager` (RM), provides authorization
 - :ref:`knowledge_graph` (KG), spans multiple services
 - :ref:`deployer` (DEP), provides (container) deployment
 - :ref:`storage` (STG), provides file storage
-- :ref:`explorer` (EXP), provides views over data stored in the knowledge graph.
+- :ref:`explorer` (EXP), provides views over data stored in the knowledge
+  graph.
 
 

--- a/docs/developer/services/storage_service.rst
+++ b/docs/developer/services/storage_service.rst
@@ -3,40 +3,57 @@
 Storage Service
 ===============
 
-Contents
---------
+.. contents::
+    :depth: 1
+    :local:
 
-- :ref:`Storage Abstraction <stg_abstraction>`
-- :ref:`Storage Endpoints <stg_endpoints>`
-- :ref:`Storage Workflow <stg_workflow>`
-- :ref:`Versioning <stg_versioning>`
-
-The storage service is a thin abstraction layer on top of various storage systems, adding the access control and auditing capabilities.
+The storage service is a thin abstraction layer on top of various storage
+systems, adding the access control and auditing capabilities.
 
 .. _stg_abstraction:
 
 Storage abstraction
 -------------------
-To be able to map to a large number of possible backends, we defined here the main concepts, directly inspired by the `Object storage <https://en.wikipedia.org/wiki/Object_storage>`_.
+
+To be able to map to a large number of possible backends, we defined here the
+main concepts, directly inspired by the `Object storage
+<https://en.wikipedia.org/wiki/Object_storage>`_.
 
 Bucket
 ^^^^^^
 
- A bucket is a container that regroups objects/files that would share some common semantics, e.g. multiple files of a same datasets or the outputs of the same execution. In addition to the globally unique identifier, a bucket has a name, an internal name, and a backend. See :ref:`here for the representation in the Knowledge Graph<kg_data>`.
+A bucket is a container that regroups objects/files that would share some
+common semantics, e.g. multiple files of a same datasets or the outputs of the
+same execution. In addition to the globally unique identifier, a bucket has a
+name, an internal name, and a backend. See :ref:`here for the representation
+in the Knowledge Graph<kg_data>`.
 
- * The name is given by the user and does not necessarily need to be unique. It is mostly used for display purposes.
- * The internal name is unique per backend instance and represents usually the folder/bucket/container name in the specific storage system.
- * The backend is a string (whose choice is limited to a given list per platform deployment) mapping to an instance of a storage backend.
+* The name is given by the user and does not necessarily need to be unique.
+  It is mostly used for display purposes.
+
+* The internal name is unique per backend instance and represents usually the
+  folder/bucket/container name in the specific storage system.
+
+* The backend is a string (whose choice is limited to a given list per
+  platform deployment) mapping to an instance of a storage backend.
 
 File
 ^^^^
 
-  A file is a sequence of bytes stored together that is agnostic of its own content. As the reading API allows for accessing directly a range of bytes, it would even by possible to abstract more complex storage structures inside a single file. However it should be noted that writing must be done all at once, in sequence (in the current implementation). In addition to the globally unique identifier, a file has only a name. The file name can contain separators such as "/", allowing to represent a folder hierarchy.
+A file is a sequence of bytes stored together that is agnostic of its own
+content. As the reading API allows for accessing directly a range of bytes, it
+would even by possible to abstract more complex storage structures inside a
+single file. However it should be noted that writing must be done all at once,
+in sequence (in the current implementation). In addition to the globally
+unique identifier, a file has only a name. The file name can contain
+separators such as "/", allowing to represent a folder hierarchy.
 
 File_Location
 ^^^^^^^^^^^^^
 
-  A file_location represents a concrete instance of a file stored in a given bucket. A file can have several file_locations, allowing for replication, caching and various optimizations.
+A file_location represents a concrete instance of a file stored in a given
+bucket. A file can have several file_locations, allowing for replication,
+caching and various optimizations.
 
 .. _stg_endpoints:
 
@@ -53,32 +70,49 @@ Authorization
 Reading
 .......
 
- **POST /authorize/read**
+    **POST /authorize/read**
 
- The json-encoded body of the request must contain a ReadResourceRequest object with the globally unique identifier of the file to read. First the corresponding graph vertices are retrieved. The service chooses then the most suited file_location, possibly forwarding the request in a federated scenario.
- Then a query to the resource manager is sent for checking the access rights and signing the access authorization. The access authorization contains all the needed information for the backend to retrieve the given file_location, in the form of a json-object that is included in the JWT claim ``resource_extras`` (You can find more details on the Resource Manager page).
- The response is validated (verifying the JWT signature and content) and forwarded to the client. The user can also provide an execution ID to record which process must be logged in the graph to have read this resource.
+    The json-encoded body of the request must contain a ReadResourceRequest
+    object with the globally unique identifier of the file to read. First the
+    corresponding graph vertices are retrieved. The service chooses then the
+    most suited file_location, possibly forwarding the request in a federated
+    scenario. Then a query to the resource manager is sent for checking the
+    access rights and signing the access authorization. The access
+    authorization contains all the needed information for the backend to
+    retrieve the given file_location, in the form of a json-object that is
+    included in the JWT claim ``resource_extras`` (You can find more details
+    on the Resource Manager page). The response is validated (verifying the
+    JWT signature and content) and forwarded to the client. The user can also
+    provide an execution ID to record which process must be logged in the
+    graph to have read this resource.
 
 Writing
 .......
 
- **POST /authorize/write**
+**POST /authorize/write**
 
- The process is identical to the previous one, with a WriteResourceRequest object. The file to write must have been first created. This will create a new version of the file. See below for the details about versioning.
+    The process is identical to the previous one, with a WriteResourceRequest
+    object. The file to write must have been first created. This will create a
+    new version of the file. See below for the details about versioning.
 
 Creating a file
 ...............
 
- **POST /authorize/create_file**
+**POST /authorize/create_file**
 
- The process is similar to the Reading and Writing, except that the request refers to the bucket into which the file should be created and which ACLs will be validated by the Resource Manager.
+    The process is similar to the Reading and Writing, except that the request
+    refers to the bucket into which the file should be created and which ACLs
+    will be validated by the Resource Manager.
 
 Creating a bucket
 .................
 
- **POST /authorize/create_bucket**
+**POST /authorize/create_bucket**
 
- To create a bucket, the body of the request must contain a CreateBucketRequest, with the definition of the bucket name, its backend and potentially some backend specific options. The authorizations is then similar to the previous processes.
+    To create a bucket, the body of the request must contain a
+    CreateBucketRequest, with the definition of the bucket name, its backend
+    and potentially some backend specific options. The authorizations is then
+    similar to the previous processes.
 
 
 Input/Output
@@ -87,38 +121,54 @@ Input/Output
 Reading a file
 ..............
 
- **GET /io/read**
+**GET /io/read**
 
- This call needs an authorization token signed by the Resource Manager and with the scope ``storage:read``. The JWT token contains in its :code:`resource_extras` claim all the needed informations for accessing the file. The :code:`Range` html header can also be used (`more info <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range>`_). The result is sent back as a chunked response.
+    This call needs an authorization token signed by the Resource Manager and
+    with the scope ``storage:read``. The JWT token contains in its
+    ``resource_extras`` claim all the needed informations for accessing the
+    file. The ``Range`` html header can also be used (`more info
+    <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range>`_). The
+    result is sent back as a chunked response.
 
 Writing a file
 ..............
 
- **POST /io/write**
+**POST /io/write**
 
- This call needs an authorization token signed by the Resource Manager and with the scope ``storage:write`` or :code:`storage:create`. The JWT token contains in its :code:`resource_extras` claim all the needed informations for accessing the file. In the case of an existing file, a new version of the file is created (see below for the versioning). The content of the file is then to be sent as the body of the request. If the authorization fails, the request is immediately aborted.
+    This call needs an authorization token signed by the Resource Manager and
+    with the scope ``storage:write`` or ``storage:create``. The JWT token
+    contains in its ``resource_extras`` claim all the needed informations for
+    accessing the file. In the case of an existing file, a new version of the
+    file is created (see below for the versioning). The content of the file is
+    then to be sent as the body of the request. If the authorization fails,
+    the request is immediately aborted.
 
 Listing backends
 ................
 
- **GET /io/backends**
+**GET /io/backends**
 
- The response is the list of all active backends on this particular deployment, that can be then used as values in the ``backend`` parameter when creating a bucket.
+    The response is the list of all active backends on this particular
+    deployment, that can be then used as values in the ``backend`` parameter
+    when creating a bucket.
 
 .. _stg_workflow:
 
 Storage access workflow
 -----------------------
 
- In a typical workflow for accessing a file, the client performs first a preflight call to the corresponding /authorize endpoint and then uses the received JWT in the Authorization header for the subsequent call to the /io endpoint.
+In a typical workflow for accessing a file, the client performs first a
+preflight call to the corresponding /authorize endpoint and then uses the
+received JWT in the Authorization header for the subsequent call to the /io
+endpoint.
 
- **/authorize/read** is followed by **/io/read**
+**/authorize/read** is followed by **/io/read**
 
- **/authorize/write** is followed by **/io/write**
+**/authorize/write** is followed by **/io/write**
 
- **/authorize/create_file** is followed by **/io/write**
+**/authorize/create_file** is followed by **/io/write**
 
- **/authorize/create_bucket** directly creates the bucket
+**/authorize/create_bucket** directly creates the bucket
 
 .. _stg_versioning:
 
@@ -128,6 +178,15 @@ Versioning
 Time-based versioning
 ^^^^^^^^^^^^^^^^^^^^^
 
-All files are automatically versioned, by the storage backend, every time a new **write** is called on an existing file. The versioning scheme consists in appending the timestamp of the authorization call to the filename. This means that two **write** calls with the same permission token would overwrite a the same file, whereas two calls with different tokens, will create two distinct versions.
+All files are automatically versioned, by the storage backend, every time a
+new **write** is called on an existing file. The versioning scheme consists in
+appending the timestamp of the authorization call to the filename. This means
+that two **write** calls with the same permission token would overwrite a the
+same file, whereas two calls with different tokens, will create two distinct
+versions.
 
-At the level of the graph, this is abstracted by ``file_version`` vertices which are linked to the :code:`file` vertex and that can have one or more :code:`file_location` vertices. File_versions have an attribute with their creation timestamp. Resolving the latest version of a file needs to get all versions and take the one with the largest timestamp.
+At the level of the graph, this is abstracted by ``file_version`` vertices
+which are linked to the ``file`` vertex and that can have one or more
+``file_location`` vertices. File_versions have an attribute with their
+creation timestamp. Resolving the latest version of a file needs to get all
+versions and take the one with the largest timestamp.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,14 +8,17 @@
 Welcome to Renga!
 =================
 
-**Renga** is a highly-scalable & secure open software platform designed to foster
-multidisciplinary data (science) collaboration across mutually untrusted
-academic and industrial institutions.
+**Renga** is a highly-scalable & secure open software platform designed to
+foster multidisciplinary data (science) collaboration across mutually
+untrusted academic and industrial institutions.
 
 The platform allows (data)scientists to:
 
-* Securely manage, share and process large-scale data across untrusted parties operating in a federated environment.
-* Automatically capture complete lineage up to original raw data for detailed traceability, auditability & reproducibility.
+* Securely manage, share and process large-scale data across untrusted parties
+  operating in a federated environment.
+
+* Automatically capture complete lineage up to original raw data for detailed
+  traceability, auditability & reproducibility.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -1,36 +1,47 @@
 .. warning::
 
-   This is a beta version of Renga
-     This platform is a (very early) beta version. It is made available to early adopters only for the purpose of getting acquainted
-     with the APIs. THIS VERSION IS NOT INTENDED TO BE USED IN PRODUCTION MODE OR WITH SENSITIVE DATA. In this first version we put the focus
-     on the knowledge representation, data lineage, data versioning, meta-data exploration, application deployments, storage, resource management,
-     and authentication. The component that will fulfill the above vision of the platform are in place, however it also includes several
-     place holders. Most notably the permission management policies will be available only in
-     the next release of the platform, which is planned for Q1 2018. Even thought the enforcement methods of the permission policies
-     are in place, the only available policy in this version is *full access to everything for all*. In addition, this being a beta version,
-     the code and default configurations has not been edited for security vulnerabilities.
-     We provide no guarantee whatsoever about the security of the data stored on this platform.
+  **This is a beta version of Renga**
+
+  This platform is a (very early) beta version. It is made available to early
+  adopters only for the purpose of getting acquainted with the APIs. THIS
+  VERSION IS NOT INTENDED TO BE USED IN PRODUCTION MODE OR WITH SENSITIVE
+  DATA. In this first version we put the focus on the knowledge
+  representation, data lineage, data versioning, meta-data exploration,
+  application deployments, storage, resource management, and authentication.
+  The component that will fulfill the above vision of the platform are in
+  place, however it also includes several place holders. Most notably the
+  permission management policies will be available only in the next release of
+  the platform, which is planned for Q1 2018. Even thought the enforcement
+  methods of the permission policies are in place, the only available policy
+  in this version is *full access to everything for all*. In addition, this
+  being a beta version, the code and default configurations has not been
+  edited for security vulnerabilities. We provide no guarantee whatsoever
+  about the security of the data stored on this platform.
 
 .. _renga_introduction:
 
 Introduction
 ============
 
-
 .. epigraph::
 
-   **Renga** (連歌), *plural* **renga**, *a genre of Japanese linked-verse poetry in which two or more poets supply alternating sections of a poem linked by verbal and thematic associations.*
+   **Renga** (連歌), *plural* **renga**, *a genre of Japanese linked-verse
+   poetry in which two or more poets supply alternating sections of a poem
+   linked by verbal and thematic associations.*
 
    -- Encyclopædia Britannica
 
-**Renga** is a highly-scalable & secure open software platform designed to foster
-multidisciplinary data (science) collaboration across mutually untrusted
-academic and industrial institutions.
+**Renga** is a highly-scalable & secure open software platform designed to
+foster multidisciplinary data (science) collaboration across mutually
+untrusted academic and industrial institutions.
 
 The platform allows (data)scientists to:
 
-* Securely manage, share and process large-scale data across untrusted parties operating in a federated environment.
-* Automatically capture complete lineage up to original raw data for detailed traceability, auditability & reproducibility.
+* Securely manage, share and process large-scale data across untrusted parties
+  operating in a federated environment.
+
+* Automatically capture complete lineage up to original raw data for detailed
+  traceability, auditability & reproducibility.
 
 Philosophy
 ----------
@@ -43,8 +54,8 @@ contributions.
 In the same spirit, **Renga's** philosophy is to mobilize and connect skills
 from the data science community, to enhance their collective intelligence, and
 to allow the discovery of knowledge without premeditation. From the users’
-perspective, it is essentially a digital canvas where data science projects are
-constantly conducted and improved, evolving asynchronously into a web of
+perspective, it is essentially a digital canvas where data science projects
+are constantly conducted and improved, evolving asynchronously into a web of
 interwoven data science threads, where the output of one analytics becomes the
 input of another.
 
@@ -55,10 +66,10 @@ the way they want.  In this form, it acts as a connected ecosystem of data,
 meta-data, analytics, and computing resources. It implements services to
 securely investigate data science problems and allows data scientists to
 evaluate, compare, and share each other’s methods and results. Participating
-organizations interact in a flat hierarchy where mutual trust between different
-administrative domains or a central authority is avoided. They are in full
-control of their respective platform services and resources, and manage them
-according to their own preferences.
+organizations interact in a flat hierarchy where mutual trust between
+different administrative domains or a central authority is avoided. They are
+in full control of their respective platform services and resources, and
+manage them according to their own preferences.
 
 The platform automatically materializes data lineage into a knowledge graph
 representation that serves as the basis for traceable and repeatable research.
@@ -67,33 +78,36 @@ science projects, allowing the lineage of any derived data to be unambiguously
 traced back to the original raw data sources in a manner that is fully
 transparent and traceable. Data lineage is automatically recorded; it includes
 the code of intermediate data transforms or data analytics and is designed to
-enable the repeatability of research. It is also non-circumventable and tamper-
-proof, and thus it can be used for governance, intellectual property
-attribution, and audit purposes (e.g. answer the question “who used my data, and
-for what purpose”). The knowledge representation also provides a trusted single
-view of truth. It is a one-stop shop to a vast collection of digital content
-that data scientists can explore to find good quality data they can trust, and
-confidently reuse in order to eliminate redundant efforts and accidental data
-duplication as much as possible.
+enable the repeatability of research. It is also non-circumventable and
+tamper-proof, and thus it can be used for governance, intellectual property
+attribution, and audit purposes (e.g. answer the question “who used my data,
+and for what purpose”). The knowledge representation also provides a trusted
+single view of truth. It is a one-stop shop to a vast collection of digital
+content that data scientists can explore to find good quality data they can
+trust, and confidently reuse in order to eliminate redundant efforts and
+accidental data duplication as much as possible.
 
 History
 -------
 
-- 2017.09.19  **Renga** 0.1.0 (Beta) is released to the public, with some of the planned features and all the faults.
+- 2017.09.19  **Renga** 0.1.0 (Beta) is released to the public, with some of
+  the planned features and all the faults.
 
-- 2017.02.06  Inauguration of the Swiss Data Science Center, design of **Renga** is started.
+- 2017.02.06  Inauguration of the Swiss Data Science Center, design of
+  **Renga** is started.
 
 
 Disclaimer
 ----------
 
-THIS SOFTWARE AND ALL ACCOMPANYING DOCUMENTATIONS ARE PROVIDED FREE "AS IS" AND
-ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+THIS SOFTWARE AND ALL ACCOMPANYING DOCUMENTATIONS ARE PROVIDED FREE "AS IS"
+AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL THE SWISS DATA SCIENCE CENTER OR CONTRIBUTORS BE
 LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/docs/user/firststeps.rst
+++ b/docs/user/firststeps.rst
@@ -21,7 +21,7 @@ command-line interface (CLI) and the Python API. You can get both via pip:
 .. note::
 
    We recommend using `virtualenv
-   <https://virtualenv.pypa.io/en/stable/>`_ when installing the ``renga``
+   <https://virtualenv.pypa.io/en/stable/>`_ when installing the Renga
    package.
 
 
@@ -111,7 +111,7 @@ At this point, we have created a project, linked it to a storage bucket
 and a container deployment. However, our "hello-world" container did not
 really do much. A more interesting container to run is an interactive
 `jupyter notebook <http://jupyter.org>`_ and if we launch it using
-``renga``, we can automatically link the creation of any derived data to
+Renga, we can automatically link the creation of any derived data to
 our project:
 
 .. code-block:: console
@@ -131,13 +131,13 @@ point you can see your current notebooks with
      1  docker    http://0.0.0.0:32956/?token=8514bb62
 
 Once inside the notebook, start a new python notebook and install
-``renga``:
+Renga:
 
 .. code-block:: ipython
 
     In [1]: !pip install renga
 
-Now we can import the ``renga`` python API and interact with the platform:
+Now we can import the Renga python API and interact with the platform:
 
 .. code-block:: ipython
 

--- a/docs/user/setup.rst
+++ b/docs/user/setup.rst
@@ -11,8 +11,8 @@ The renga source code is hosted on github:
 https://github.com/SwissDataScienceCenter/renga.
 
 Renga is deployed as a collection of microservices (see
-:ref:`service_architecture`) running in Docker containers. To run Renga, only a
-working version of Docker is required. In the Renga repository, we provide a
+:ref:`service_architecture`) running in Docker containers. To run Renga, only
+a working version of Docker is required. In the Renga repository, we provide a
 `docker-compose` file, which can be used to deploy renga quickly either on a
 local machine or with a cloud provider. However, be aware that if you want to
 use Renga in production with many users, a more complicated deployment will be
@@ -22,9 +22,15 @@ Prerequisites
 -------------
 
 * `Docker <http://www.docker.com>`_
-* `Docker Compose >=1.14 <https://docs.docker.com/compose/install/>`_ (**Linux Only**)
+* `Docker Compose >=1.14 <https://docs.docker.com/compose/install/>`_
+  (**Linux Only**)
 * `GNU make <https://www.gnu.org/software/make/>`_
 * `sbt <http://www.scala-sbt.org/>`_
+
+.. note::
+
+    On Mac OS X, we recommend that you set the amount of memory available
+    to Docker to 6GB (under Docker Preferences --> Advanced).
 
 
 Getting the code and images
@@ -39,8 +45,8 @@ Get the platform
     $ cd src
     $ git clone https://github.com/SwissDataScienceCenter/renga.git
 
-``renga`` is the "parent" repository of the collection of microservices, each of
-which has their own repository.
+``renga`` is the "parent" repository of the collection of microservices, each
+of which has their own repository.
 
 
 .. _quickstart:
@@ -55,12 +61,13 @@ You can get going with Renga in a few minutes by using our pre-built images:
     $ cd renga
     $ make start
 
-Once the script completes, you can go to http://localhost/ui to see the browser
-front-end or http://localhost/admin/swagger/ to see the Swagger REST API.
+Once the script completes, you can go to http://localhost/ui to see the
+browser front-end or http://localhost/admin/swagger/ to see the Swagger REST
+API.
 
-Using the default configuration, you can login to all services using `demo/demo`
-as the username/password. See :ref:`user_management` for more information about
-handling user accounts.
+Using the default configuration, you can login to all services using
+`demo/demo` as the username/password. See :ref:`user_management` for more
+information about handling user accounts.
 
 
 Building from source
@@ -71,8 +78,9 @@ Building from source
     $ cd renga
     $ make
 
-``make`` assumes that the base directory of the platform is the parent directory
-of `renga`. If you want to specify a different path, use the ``-e`` option:
+``make`` assumes that the base directory of the platform is the parent
+directory of `renga`. If you want to specify a different path, use the ``-e``
+option:
 
 .. code-block:: console
 
@@ -138,8 +146,8 @@ commands:
     renga_swagger_1            sh /usr/share/nginx/docker ...   Up
     renga_ui_1                 python3 /app/server/run.py       Up
 
-You can now point your browser to http://localhost/ui for the web front-end, or
-to http://localhost/admin/swagger for the swagger REST API spec.
+You can now point your browser to http://localhost/ui for the web front-end,
+or to http://localhost/admin/swagger for the swagger REST API spec.
 
 
 Identification Management
@@ -165,7 +173,7 @@ Platform Endpoint
 By default, the platform is configured to use ``http://localhost`` as the
 endpoint. You can change this by defining the ``RENGA_ENDPOINT`` environment
 variable before starting the platform services. In addition, the containers
-spawned by the endpoint run in the default bridge network. If you would like to
-change this, set the ``RENGA_CONTAINERS_ENDPOINT`` to point to either the
+spawned by the endpoint run in the default bridge network. If you would like
+to change this, set the ``RENGA_CONTAINERS_ENDPOINT`` to point to either the
 gateway IP of the docker network you would like to use, a public IP, or a DNS-
 resolvable hostname. The endpoint definition should include

--- a/docs/user/troubleshooting.rst
+++ b/docs/user/troubleshooting.rst
@@ -14,12 +14,14 @@ Building the code
 
 **Q**: I get an issue with docker.sock if I don't run as root?
 
-**A**: Add your user to the docker group `as explained here <https://docs.docker.com/engine/installation/linux/linux-postinstall/#manage-docker-as-a-non-root-user>`_.
+**A**: Add your user to the docker group `as explained here
+<https://docs.docker.com/engine/installation/linux/linux-postinstall/#manage-docker-as-a-non-root-user>`_.
 
 Using Swagger
 -------------
 
-**Q**: Upon creating a bucket with POST /authorize/create_bucket I get a failed response after a successful creation.
+**Q**: Upon creating a bucket with POST /authorize/create_bucket I get a
+failed response after a successful creation.
 
 Example::
 
@@ -33,19 +35,27 @@ Example::
        "timestamp": "2017-08-10T10:29:51.923Z"
      }
 
-**A**: The bucket has been created properly but failed to write to the graph. Check the docker-compose version, if the version is not very recent, try upgrading docker-compose (it has been tested on Docker-compose version 1.14.0)
+**A**: The bucket has been created properly but failed to write to the graph.
+Check the docker-compose version, if the version is not very recent, try
+upgrading docker-compose (it has been tested on Docker-compose version
+1.14.0)
 
 Using the web UI
 ----------------
 
-**Q**: I get always redirected to a blank page or I'm stuck in a redirection loop.
+**Q**: I get always redirected to a blank page or I'm stuck in a redirection
+loop.
 
-**A**: The API token expired and the refresh token too. Just logout and login again.
+**A**: The API token expired and the refresh token too. Just logout and login
+again.
 
-**Q**: I'm adding files/buckets/contexts/... but the graph view does not change.
+**Q**: I'm adding files/buckets/contexts/... but the graph view does not
+change.
 
-**A**: Changing pages does not refresh yet the content of the displayed graph. You need to refresh the whole page, by pressing F5 for example.
+**A**: Changing pages does not refresh yet the content of the displayed graph.
+You need to refresh the whole page, by pressing F5 for example.
 
 **Q**: While navigating the graph, it disappeared.
 
-**A**: You may have zoomed in too much in an empty region. You can try to zoom out or refresh the page.
+**A**: You may have zoomed in too much in an empty region. You can try to
+zoom out or refresh the page.


### PR DESCRIPTION
* reformat all pages to common width (79 + newline)
* add multi-resource seq. diagram example
* add note about mac os x memory requirements
* replace :code: with ``

closes #94  
closes #96 