### PR TITLE
Configure Renga repository for new ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,8 @@ endif
 			--docker-image $(DOCKER_PREFIX)renga-python:$(PLATFORM_VERSION) \
 			--docker-pull-policy "if-not-present"; \
 	done
-
+	@echo
+	@echo "[Info] Edit gitlab/runner/config.toml to increase the number of concurrent runner jobs."
 unregister-runners:
 	@for container in $(shell $(DOCKER_COMPOSE_ENV) docker-compose ps -q gitlab-runner) ; do \
 		docker exec -ti $$container gitlab-runner unregister \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 
 ifndef RENGA_UI_URL
 	# The ui should run under localhost instead of docker.for.mac.localhost
-	RENGA_UI_URL=http://localhost:5000
+	RENGA_UI_URL=http://localhost
 	export RENGA_UI_URL
 endif
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,9 @@ services:
       GITLAB_URL: ${GITLAB_URL}
       RENGA_UI_URL: ${RENGA_UI_URL}
       RENGA_ENDPOINT: ${RENGA_ENDPOINT}
+    labels:
+      traefik.enable: "true"
+      traefik.frontend.rule: PathPrefix:/
 
   reverse-proxy:
     image: traefik

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
       POSTGRES_PORT_5432_TCP_ADDR: db
       POSTGRES_USER: keycloak
       RENGA_ENDPOINT: ${RENGA_ENDPOINT}
+      GITLAB_URL: ${GITLAB_URL}
+      RENGA_UI_URL: ${RENGA_UI_URL}
+      GITLAB_CLIENT_SECRET: ${GITLAB_CLIENT_SECRET}
     ports:
       - 8080
     command:
@@ -85,22 +88,27 @@ services:
         #gitlab_rails['db_adapter'] = 'postgresql'
         #gitlab_rails['db_encoding'] = 'utf8'
         gitlab_rails['omniauth_enabled'] = true
-        gitlab_rails['omniauth_allow_single_sign_on'] = ['saml']
-        gitlab_rails['omniauth_auto_link_saml_user'] = true
+        gitlab_rails['omniauth_allow_single_sign_on'] = ['oauth2_generic']
         gitlab_rails['omniauth_block_auto_created_users'] = false
         gitlab_rails['omniauth_providers'] = [
           {
-            name: 'saml',
-            args: {
-              assertion_consumer_service_url: '${GITLAB_URL}/users/auth/saml/callback',
-              idp_cert: '-----BEGIN CERTIFICATE-----MIICmTCCAYECBgFePWfDJjANBgkqhkiG9w0BAQsFADAQMQ4wDAYDVQQDDAVSZW5nYTAeFw0xNzA5MDExMjI0MjNaFw0yNzA5MDExMjI2MDNaMBAxDjAMBgNVBAMMBVJlbmdhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjw2hj0o98jYxT0Z8hbd6INgJkVs2JvT6zXhHkN0UUWjGcRHF3e7Sc9GNI9wYljnBw47jqSmy2EftZ0UkGNjLENmGuLVC5r6vTneXfUht5t0+e5VelnM7yF7m9V3w/ms4wc0vDmSMa7pO5Vb+qjsTHgLTjQVqBIhGshxmZzKk6XDDVRlXe3SfLqwLX1biBmmvEOadU+2RhsHVW4rYMEaEHO1tCvRTsqiD7gVfk0XzZQg6KBEr2pDhz7hdWAfWK+/k1JiK/MNTs3FCfOqoBlTa6dZB/XRrKx0Pbi7y5Cr6BqqPUJzW5dbCYRzjmjL5CYx4KYHAjSSoCCpUjCHLILPPJQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQARL3CB1iaT9bQSf+XYN69HK6mIL6celrZxoWF5ugKXfioIadAK/Pm76zT0QHHjlgfC/ln6sjU9pnVEbIyioRM0zgVuegSogt18qw3tRLTp3swA71v7EwGjGc79c+5q2JgTpkjMaf38lebm6E9CRye4chY9Ku9+GpZlQRR3L1L0OtdQAWvapBoIWdQJuJjI1KYIH+iKybSCKE3IVM2llWWg0K78PuWMm7euSYO3PLtR+FzdpS0YqDMHZNXIZtFPbvgeO6AfYXV0pSjM/q4OYEEYM7EKnaCHx1+/QcxrVVjcyck/n2tUE9AblAHot3oypy1u7YFDPg2W8QH+UediubTv-----END CERTIFICATE-----',
-              idp_sso_target_url: '${RENGA_ENDPOINT}/auth/realms/Renga/protocol/saml',
-              issuer: 'gitlab',
-              name_identifier_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-              attribute_statements: {
-                email: ['urn:oid:1.2.840.113549.1.9.1'],
-                first_name: ['urn:oid:2.5.4.4'],
-                last_name: ['urn:oid:2.5.4.42']
+            'name' => 'oauth2_generic',
+            'app_id' => 'gitlab',
+            'app_secret' => '${GITLAB_CLIENT_SECRET}',
+            'args' => {
+              client_options: {
+                # Traefik maps keycloak to the URL below
+                # CAREFUL: This must be accessible from inside the keycloak container
+                # for server-to-server communication.
+                # Use docker.for.mac.localhost as RENGA_ENDPOINT for example.
+                'site' => '${RENGA_ENDPOINT}/auth/',
+                'authorize_url' => '/auth/realms/Renga/protocol/openid-connect/auth',
+                'user_info_url' => '/auth/realms/Renga/protocol/openid-connect/userinfo',
+                'token_url' => '/auth/realms/Renga/protocol/openid-connect/token'
+              },
+              user_response_structure: {
+                attributes: { email:'email', first_name:'given_name', last_name:'family_name', name:'name', nickname:'preferred_username' }, # if the nickname attribute of a user is called 'username'
+                id_path: 'preferred_username'
               }
             },
             label: 'Renga Login'
@@ -157,18 +165,17 @@ services:
 #       traefik.enable: "true"
 #       traefik.frontend.rule: PathPrefix:/api/storage
 
-#   ui:
-#     image: ${DOCKER_REPOSITORY}renga-ui:$PLATFORM_VERSION
-#     ports:
-#       - 5000
-#     environment:
-#       API_ROOT_URL: http://reverse-proxy/api/
-#       APPLICATION_ROOT: /ui
-#       KEYCLOAK_REDIRECT_URL: ${RENGA_ENDPOINT}/auth/realms/Renga/  # from outside
-#       KEYCLOAK_URL: http://reverse-proxy/auth/realms/Renga/  # from inside
-#     labels:
-#       traefik.enable: "true"
-#       traefik.frontend.rule: PathPrefix:/ui
+
+
+  ui:
+    image: ${DOCKER_PREFIX}renga-ui:${PLATFORM_VERSION}
+    restart: always
+    ports:
+      - 5000:3000
+    environment:
+      GITLAB_URL: ${GITLAB_URL}
+      RENGA_UI_URL: ${RENGA_UI_URL}
+      RENGA_ENDPOINT: ${RENGA_ENDPOINT}
 
   reverse-proxy:
     image: traefik

--- a/services/keycloak/docker-entrypoint.sh
+++ b/services/keycloak/docker-entrypoint.sh
@@ -20,10 +20,17 @@
 echo "==================================================="
 echo " Configuration:"
 echo " RENGA_ENDPOINT=$RENGA_ENDPOINT"
+echo " GITLAB_URL=$GITLAB_URL"
+echo " RENGA_UI_URL=$RENGA_UI_URL"
 echo " KEYCLOAK_MIGRATION_FILE=$KEYCLOAK_MIGRATION_FILE"
 echo "==================================================="
 
-sed -e "s|{{RENGA_ENDPOINT}}|${RENGA_ENDPOINT}|" "$KEYCLOAK_MIGRATION_FILE.tpl" > "$KEYCLOAK_MIGRATION_FILE"
+cat $KEYCLOAK_MIGRATION_FILE.tpl \
+  | sed -e "s|{{RENGA_ENDPOINT}}|${RENGA_ENDPOINT}|" \
+  | sed -e "s|{{RENGA_UI_URL}}|${RENGA_UI_URL}|" \
+  | sed -e "s|{{GITLAB_URL}}|${GITLAB_URL}|" \
+  | sed -e "s|{{GITLAB_CLIENT_SECRET}}|${GITLAB_CLIENT_SECRET}|" \
+  > $KEYCLOAK_MIGRATION_FILE
 
 exec /opt/jboss/docker-entrypoint.sh $@
 exit $?

--- a/services/keycloak/renga-realm.json.tpl
+++ b/services/keycloak/renga-realm.json.tpl
@@ -346,7 +346,351 @@
       "roles" : [ "realm-admin" ]
     } ]
   },
-  "clients" : [ {
+  "clients" : [
+  {
+    "id": "4622f33f-e0ca-401f-b6a5-a5e55f937ffb",
+    "clientId": "renga-ui",
+    "adminUrl": "",
+    "rootUrl": "{{RENGA_UI_URL}}",
+    "baseUrl": "{{RENGA_UI_URL}}",
+    "surrogateAuthRequired": false,
+    "enabled": true,
+    "clientAuthenticatorType": "client-secret",
+    "secret": "no-secret-defined",
+    "redirectUris": [
+      "/*"
+    ],
+    "webOrigins": [
+      "{{RENGA_UI_URL}}"
+    ],
+    "notBefore": 0,
+    "bearerOnly": false,
+    "consentRequired": false,
+    "standardFlowEnabled": true,
+    "implicitFlowEnabled": false,
+    "directAccessGrantsEnabled": false,
+    "serviceAccountsEnabled": false,
+    "publicClient": true,
+    "frontchannelLogout": false,
+    "protocol": "openid-connect",
+    "attributes": {
+      "saml.assertion.signature": "false",
+      "saml.force.post.binding": "false",
+      "saml.multivalued.roles": "false",
+      "saml.encrypt": "false",
+      "saml_force_name_id_format": "false",
+      "saml.client.signature": "false",
+      "saml.authnstatement": "false",
+      "saml.server.signature": "false",
+      "saml.server.signature.keyinfo.ext": "false",
+      "saml.onetimeuse.condition": "false"
+    },
+    "fullScopeAllowed": true,
+    "nodeReRegistrationTimeout": -1,
+    "protocolMappers": [
+      {
+        "id": "7d833565-cb26-46eb-9e2c-13ffe924cddf",
+        "name": "given name",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${givenName}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "firstName",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "given_name",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "fab105c9-aa79-4110-be5d-9e98b5801b99",
+        "name": "family name",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${familyName}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "lastName",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "family_name",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "e967d8b0-9af5-451c-a7fc-8cc65df22554",
+        "name": "full name",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-full-name-mapper",
+        "consentRequired": true,
+        "consentText": "${fullName}",
+        "config": {
+          "id.token.claim": "true",
+          "access.token.claim": "true"
+        }
+      },
+      {
+        "id": "4bbc3374-3d02-482f-b69f-bf3a79d0c305",
+        "name": "email",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${email}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "email",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "email",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "44480bbc-f397-4a43-870b-d9ed28489044",
+        "name": "role list",
+        "protocol": "saml",
+        "protocolMapper": "saml-role-list-mapper",
+        "consentRequired": false,
+        "config": {
+          "single": "false",
+          "attribute.nameformat": "Basic",
+          "attribute.name": "Role"
+        }
+      },
+      {
+        "id": "0c4ca494-2f26-4b9a-93bc-0a53c4a4f984",
+        "name": "username",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${username}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "username",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "preferred_username",
+          "jsonType.label": "String"
+        }
+      }
+    ],
+    "useTemplateConfig": false,
+    "useTemplateScope": false,
+    "useTemplateMappers": false
+  }, {
+    "id": "0c9dab4c-ce06-44a7-ba4e-6ce969c5e5cb",
+    "clientId": "gitlab",
+    "baseUrl": "{{GITLAB_URL}}",
+    "surrogateAuthRequired": false,
+    "enabled": true,
+    "clientAuthenticatorType": "client-secret",
+    "secret": "{{GITLAB_CLIENT_SECRET}}",
+    "redirectUris": [
+      "{{GITLAB_URL}}/users/auth/oauth2_generic/callback"
+    ],
+    "webOrigins": [],
+    "notBefore": 0,
+    "bearerOnly": false,
+    "consentRequired": false,
+    "standardFlowEnabled": true,
+    "implicitFlowEnabled": false,
+    "directAccessGrantsEnabled": true,
+    "serviceAccountsEnabled": true,
+    "authorizationServicesEnabled": true,
+    "publicClient": false,
+    "frontchannelLogout": false,
+    "protocol": "openid-connect",
+    "attributes": {
+      "saml.assertion.signature": "false",
+      "saml.force.post.binding": "false",
+      "saml.multivalued.roles": "false",
+      "saml.encrypt": "false",
+      "saml_force_name_id_format": "false",
+      "saml.client.signature": "false",
+      "saml.authnstatement": "false",
+      "saml.server.signature": "false",
+      "saml.server.signature.keyinfo.ext": "false",
+      "saml.onetimeuse.condition": "false"
+    },
+    "fullScopeAllowed": true,
+    "nodeReRegistrationTimeout": -1,
+    "protocolMappers": [
+      {
+        "id": "55ef06ad-d8db-4703-8cf7-6cd2a8abddba",
+        "name": "full name",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-full-name-mapper",
+        "consentRequired": true,
+        "consentText": "${fullName}",
+        "config": {
+          "id.token.claim": "true",
+          "access.token.claim": "true"
+        }
+      },
+      {
+        "id": "dee69859-6790-4a9d-83c1-2c1147a7351c",
+        "name": "given name",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${givenName}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "firstName",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "given_name",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "df709193-9c41-48e8-be13-af820318ae81",
+        "name": "Client Host",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usersessionmodel-note-mapper",
+        "consentRequired": false,
+        "consentText": "",
+        "config": {
+          "user.session.note": "clientHost",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "clientHost",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "ccc60a25-e3aa-48a0-9fea-dfa280df0333",
+        "name": "username",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${username}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "username",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "preferred_username",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "1e4f7f5d-e947-4197-bfdd-9f694396fe51",
+        "name": "role list",
+        "protocol": "saml",
+        "protocolMapper": "saml-role-list-mapper",
+        "consentRequired": false,
+        "config": {
+          "single": "false",
+          "attribute.nameformat": "Basic",
+          "attribute.name": "Role"
+        }
+      },
+      {
+        "id": "a25924f5-8185-4d0d-aa4f-81d424b687d3",
+        "name": "Client IP Address",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usersessionmodel-note-mapper",
+        "consentRequired": false,
+        "consentText": "",
+        "config": {
+          "user.session.note": "clientAddress",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "clientAddress",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "fddbb4a8-1052-4b68-a6b4-c433d4e00fdc",
+        "name": "Client ID",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usersessionmodel-note-mapper",
+        "consentRequired": false,
+        "consentText": "",
+        "config": {
+          "user.session.note": "clientId",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "clientId",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "28ab5b96-66f0-4b96-be96-1916ae8799c0",
+        "name": "email",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${email}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "email",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "email",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "c915b73d-f49f-4a58-89f3-8ebc197da44b",
+        "name": "family name",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${familyName}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "lastName",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "family_name",
+          "jsonType.label": "String"
+        }
+      }
+    ],
+    "useTemplateConfig": false,
+    "useTemplateScope": false,
+    "useTemplateMappers": false,
+    "authorizationSettings": {
+      "allowRemoteResourceManagement": false,
+      "policyEnforcementMode": "ENFORCING",
+      "resources": [
+        {
+          "name": "Default Resource",
+          "uri": "/*",
+          "type": "urn:gitlab:resources:default"
+        }
+      ],
+      "policies": [
+        {
+          "name": "Default Policy",
+          "description": "A policy that grants access only for users within this realm",
+          "type": "js",
+          "logic": "POSITIVE",
+          "decisionStrategy": "AFFIRMATIVE",
+          "config": {
+            "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+          }
+        },
+        {
+          "name": "Default Permission",
+          "description": "A permission that applies to the default resource type",
+          "type": "resource",
+          "logic": "POSITIVE",
+          "decisionStrategy": "UNANIMOUS",
+          "config": {
+            "defaultResourceType": "urn:gitlab:resources:default",
+            "applyPolicies": "[\"Default Policy\"]"
+          }
+        }
+      ],
+      "scopes": []
+    }
+  }, {
     "id" : "84027d06-f768-40f0-a6c7-c1e4fb405b76",
     "clientId" : "account",
     "name" : "${client_account}",

--- a/services/keycloak/renga-realm.json.tpl
+++ b/services/keycloak/renga-realm.json.tpl
@@ -15,8 +15,8 @@
   "actionTokenGeneratedByUserLifespan" : 300,
   "enabled" : true,
   "sslRequired" : "external",
-  "registrationAllowed" : false,
-  "registrationEmailAsUsername" : false,
+  "registrationAllowed" : true,
+  "registrationEmailAsUsername" : true,
   "rememberMe" : false,
   "verifyEmail" : false,
   "loginWithEmailAllowed" : true,
@@ -351,14 +351,13 @@
     "id": "4622f33f-e0ca-401f-b6a5-a5e55f937ffb",
     "clientId": "renga-ui",
     "adminUrl": "",
-    "rootUrl": "{{RENGA_UI_URL}}",
     "baseUrl": "{{RENGA_UI_URL}}",
     "surrogateAuthRequired": false,
     "enabled": true,
     "clientAuthenticatorType": "client-secret",
     "secret": "no-secret-defined",
     "redirectUris": [
-      "/*"
+      "{{RENGA_UI_URL}}/*"
     ],
     "webOrigins": [
       "{{RENGA_UI_URL}}"


### PR DESCRIPTION
Note: UI is still served by webpack dev server so far - not suitable for production.
 - Fix keycloak login for gitlab
 - Preregister gitlab and the ui as keycloak clients
 - Preregister ui as oauth client with gitlab
 - Add ui as a service to docker-compose

--
addresses #117 