### PR TITLE
Adapt ui client urls for dev setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ services/gitlab/%:
 register-gitlab-oauth-applications: unregister-gitlab-oauth-applications
 	@$(DOCKER_COMPOSE_ENV) docker-compose exec gitlab /opt/gitlab/bin/gitlab-psql \
 		-h /var/opt/gitlab/postgresql -d gitlabhq_production \
-		-c "INSERT INTO oauth_applications (name, uid, scopes, redirect_uri, secret, trusted) VALUES ('renga-ui', 'renga-ui', 'api read_user', '$(RENGA_UI_URL)/login/redirect/gitlab', 'no-secret-needed', 'true')"
+		-c "INSERT INTO oauth_applications (name, uid, scopes, redirect_uri, secret, trusted) VALUES ('renga-ui', 'renga-ui', 'api read_user', '$(RENGA_UI_URL)/login/redirect/gitlab http://localhost:3000/login/redirect/gitlab', 'no-secret-needed', 'true')"
 
 unregister-gitlab-oauth-applications:
 	@$(DOCKER_COMPOSE_ENV) docker-compose exec gitlab /opt/gitlab/bin/gitlab-psql \

--- a/services/keycloak/renga-realm.json.tpl
+++ b/services/keycloak/renga-realm.json.tpl
@@ -357,10 +357,12 @@
     "clientAuthenticatorType": "client-secret",
     "secret": "no-secret-defined",
     "redirectUris": [
-      "{{RENGA_UI_URL}}/*"
+      "{{RENGA_UI_URL}}/*",
+      "http://localhost:3000/*"
     ],
     "webOrigins": [
-      "{{RENGA_UI_URL}}"
+      "{{RENGA_UI_URL}}",
+      "http://localhost:3000"
     ],
     "notBefore": 0,
     "bearerOnly": false,


### PR DESCRIPTION
Added http://localhost:3000 as allowed renga-ui client url  to gitlab and keycloak setup for a better ui development setting.