### PR TITLE
eliminate using localhost everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,7 @@ else
     detected_OS := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 endif
 
-ifeq ($(detected_OS), Darwin)
-	PLATFORM_DOMAIN?=docker.for.mac.localhost
-else
-	PLATFORM_DOMAIN?=localhost
-endif
+PLATFORM_DOMAIN?=renga.local
 
 PLATFORM_BASE_DIR?=..
 PLATFORM_BASE_REPO_URL?=https://github.com/SwissDataScienceCenter
@@ -39,8 +35,8 @@ endif
 
 GIT_MASTER_HEAD_SHA:=$(shell git rev-parse --short=12 --verify HEAD)
 
-GITLAB_URL?=http://$(PLATFORM_DOMAIN):5080
-GITLAB_REGISTRY_URL?=http://$(PLATFORM_DOMAIN):5081
+GITLAB_URL?=http://gitlab.$(PLATFORM_DOMAIN)
+GITLAB_REGISTRY_URL?=http://gitlab.$(PLATFORM_DOMAIN):5081
 GITLAB_DIRS=config logs git-data lfs-data runner
 
 DOCKER_REPOSITORY?=rengahub/
@@ -68,7 +64,7 @@ endif
 
 ifndef RENGA_UI_URL
 	# The ui should run under localhost instead of docker.for.mac.localhost
-	RENGA_UI_URL=http://localhost
+	RENGA_UI_URL=http://$(PLATFORM_DOMAIN)
 	export RENGA_UI_URL
 endif
 
@@ -184,12 +180,12 @@ services/gitlab/%:
 register-gitlab-oauth-applications: unregister-gitlab-oauth-applications
 	@$(DOCKER_COMPOSE_ENV) docker-compose exec gitlab /opt/gitlab/bin/gitlab-psql \
 		-h /var/opt/gitlab/postgresql -d gitlabhq_production \
-		-c "INSERT INTO oauth_applications (name, uid, scopes, redirect_uri, secret, trusted) VALUES ('renga-ui', 'renga-ui', 'api read_user', '$(RENGA_UI_URL)/login/redirect/gitlab http://localhost:3000/login/redirect/gitlab', 'no-secret-needed', 'true')"
+		-c "INSERT INTO oauth_applications (name, uid, scopes, redirect_uri, secret, trusted) VALUES ('renga-ui', 'renga-ui', 'api read_user', '$(RENGA_UI_URL)/login/redirect/gitlab http://localhost:3000/login/redirect/gitlab', 'no-secret-needed', 'true')" >& /dev/null
 
 unregister-gitlab-oauth-applications:
 	@$(DOCKER_COMPOSE_ENV) docker-compose exec gitlab /opt/gitlab/bin/gitlab-psql \
 		-h /var/opt/gitlab/postgresql -d gitlabhq_production \
-		-c "DELETE FROM oauth_applications WHERE uid='renga-ui'"
+		-c "DELETE FROM oauth_applications WHERE uid='renga-ui'" >& /dev/null
 
 register-runners: unregister-runners
 ifeq (${RUNNER_TOKEN},)
@@ -243,6 +239,14 @@ ifeq (${GITLAB_CLIENT_SECRET}, dummy-secret)
 	@echo "[Warning] You have not defined a GITLAB_CLIENT_SECRET. Using dummy"
 	@echo "          secret instead. Never do this in production!"
 	@echo
+endif
+ifeq ($(shell ping -c1 ${PLATFORM_DOMAIN} && ping -c1 gitlab.${PLATFORM_DOMAIN} && ping -c1 keycloak.${PLATFORM_DOMAIN}), )
+	@echo
+	@echo "[Error] Services unreachable -- if running locally, ensure name resolution with: "
+	@echo
+	@echo "$$ echo \"127.0.0.1 $(PLATFORM_DOMAIN) keycloak.$(PLATFORM_DOMAIN) gitlab.$(PLATFORM_DOMAIN)\" | sudo tee -a /etc/hosts"
+	@echo
+	@exit 1
 endif
 	@echo
 	@echo "[Success] Renga UI should be under $(RENGA_UI_URL) and GitLab under $(GITLAB_URL)"

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,10 @@ DOCKER_NETWORK?=review
 DOCKER_COMPOSE_ENV=\
 	DOCKER_PREFIX=$(DOCKER_PREFIX) \
 	DOCKER_REPOSITORY=$(DOCKER_REPOSITORY) \
-	GITLAB_URL=$(GITLAB_URL) \
-	GITLAB_REGISTRY_URL=$(GITLAB_REGISTRY_URL) \
 	GITLAB_CLIENT_SECRET=$(GITLAB_CLIENT_SECRET) \
+	GITLAB_REGISTRY_URL=$(GITLAB_REGISTRY_URL) \
+	GITLAB_URL=$(GITLAB_URL) \
+	KEYCLOAK_URL=$(KEYCLOAK_URL) \
 	PLATFORM_DOMAIN=$(PLATFORM_DOMAIN) \
 	PLATFORM_VERSION=$(PLATFORM_VERSION) \
 	RENGA_ENDPOINT=$(RENGA_ENDPOINT) \
@@ -56,6 +57,11 @@ DOCKER_COMPOSE_ENV=\
 SBT_IVY_DIR := $(PWD)/.ivy
 SBT = sbt -ivy $(SBT_IVY_DIR)
 SBT_PUBLISH_TARGET = publish-local
+
+ifndef KEYCLOAK_URL
+	KEYCLOAK_URL=http://keycloak.$(PLATFORM_DOMAIN)
+	export KEYCLOAK_URL
+endif
 
 ifndef RENGA_ENDPOINT
 	RENGA_ENDPOINT=http://$(PLATFORM_DOMAIN)
@@ -204,6 +210,7 @@ endif
 			--run-untagged=false \
 			--tag-list notebook \
 			--docker-image $(DOCKER_PREFIX)renga-python:$(PLATFORM_VERSION) \
+			--docker-network-mode=review \
 			--docker-pull-policy "if-not-present"; \
 		docker exec -ti $$container gitlab-runner register \
 			-n -u $(GITLAB_URL) \
@@ -216,6 +223,7 @@ endif
 			--run-untagged=false \
 			--tag-list cwl \
 			--docker-image $(DOCKER_PREFIX)renga-python:$(PLATFORM_VERSION) \
+			--docker-network-mode=review \
 			--docker-pull-policy "if-not-present"; \
 	done
 	@echo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
     volumes:
       - ./services/postgres/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:ro
       - db-data:/pgdata
-    ports:
-      - 5432
     networks:
       - default
 
@@ -49,8 +47,6 @@ services:
       GITLAB_URL: ${GITLAB_URL}
       RENGA_UI_URL: ${RENGA_UI_URL}
       GITLAB_CLIENT_SECRET: ${GITLAB_CLIENT_SECRET}
-    ports:
-      - 8080
     command:
       - "-b 0.0.0.0"
       - "-Dkeycloak.migration.action=import"
@@ -102,9 +98,8 @@ services:
               client_options: {
                 # Traefik maps keycloak to the URL below
                 # CAREFUL: This must be accessible from inside the keycloak container
-                # for server-to-server communication.
-                # Use docker.for.mac.localhost as RENGA_ENDPOINT for example.
-                'site' => 'http://keycloak.${PLATFORM_DOMAIN}:8080/auth',
+                # for service-to-service communication.
+                'site' => 'http://{KEYCLOAK_URL}/auth',
                 'authorize_url' => '/auth/realms/Renga/protocol/openid-connect/auth',
                 'user_info_url' => '/auth/realms/Renga/protocol/openid-connect/userinfo',
                 'token_url' => '/auth/realms/Renga/protocol/openid-connect/token'
@@ -123,8 +118,6 @@ services:
         gitlab_rails['initial_root_password'] = 'root_password'
         # Add any other gitlab.rb configuration here, each on its own line
     ports:
-      - 80
-      - '5443:443'
       - '5022:22'
     volumes:
       - ./services/gitlab/config:/etc/gitlab
@@ -141,6 +134,9 @@ services:
       default:
         aliases:
           - gitlab.${PLATFORM_DOMAIN}
+      review:
+        aliases:
+          - gitlab.${PLATFORM_DOMAIN}
 
   gitlab-runner:
     image: ${DOCKER_PREFIX}gitlab-runner:${PLATFORM_VERSION}
@@ -155,6 +151,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - default
+      - review
 
 #   storage:
 #     image: ${DOCKER_REPOSITORY}renga-storage:$PLATFORM_VERSION
@@ -178,13 +175,11 @@ services:
   ui:
     image: ${DOCKER_PREFIX}renga-ui:${PLATFORM_VERSION}
     restart: always
-    ports:
-      - 3000
     environment:
       GITLAB_URL: ${GITLAB_URL}
       RENGA_UI_URL: http://${PLATFORM_DOMAIN}
       RENGA_ENDPOINT: ${RENGA_ENDPOINT}
-      KEYCLOAK_URL: http://keycloak.${PLATFORM_DOMAIN}:8080
+      KEYCLOAK_URL: ${KEYCLOAK_URL}
     labels:
       traefik.enable: "true"
       traefik.frontend.rule: PathPrefix:/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@
 version: '3'
 volumes:
   db-data: {}
-  cassandra-data: {}
 services:
   db:
     image: postgres:9.6
@@ -61,11 +60,15 @@ services:
     restart: on-failure
     labels:
       traefik.enable: "true"
-      traefik.frontend.rule: PathPrefix:/auth
+      traefik.frontend.rule: "Host:keycloak.${PLATFORM_DOMAIN}"
+      traefik.frontend.entryPoints: "service, http"
+      traefik.frontend.redirect.entryPoint: "service"
     depends_on:
       - db
     networks:
-      - default
+      default:
+        aliases:
+          - keycloak.${PLATFORM_DOMAIN}
 
   gitlab:
     image: gitlab/gitlab-ce:latest
@@ -101,7 +104,7 @@ services:
                 # CAREFUL: This must be accessible from inside the keycloak container
                 # for server-to-server communication.
                 # Use docker.for.mac.localhost as RENGA_ENDPOINT for example.
-                'site' => '${RENGA_ENDPOINT}/auth/',
+                'site' => 'http://keycloak.${PLATFORM_DOMAIN}:8080/auth',
                 'authorize_url' => '/auth/realms/Renga/protocol/openid-connect/auth',
                 'user_info_url' => '/auth/realms/Renga/protocol/openid-connect/userinfo',
                 'token_url' => '/auth/realms/Renga/protocol/openid-connect/token'
@@ -120,7 +123,7 @@ services:
         gitlab_rails['initial_root_password'] = 'root_password'
         # Add any other gitlab.rb configuration here, each on its own line
     ports:
-      - '5080:5080'
+      - 80
       - '5443:443'
       - '5022:22'
     volumes:
@@ -130,17 +133,22 @@ services:
       - ./services/gitlab/lfs-data:/var/storage/lfs-objects
     depends_on:
       - db
-      - keycloak
+    labels:
+      traefik.enable: "true"
+      traefik.frontend.rule: Host:gitlab.${PLATFORM_DOMAIN}
+      traefik.port: '80'
     networks:
-      - default
+      default:
+        aliases:
+          - gitlab.${PLATFORM_DOMAIN}
 
   gitlab-runner:
     image: ${DOCKER_PREFIX}gitlab-runner:${PLATFORM_VERSION}
     environment:
-      RENGA_OIC_URL: ${RENGA_ENDPOINT}/auth/realms/Renga/,
+      RENGA_OIC_URL: ${RENGA_ENDPOINT}/auth/realms/Renga/
       RENGA_OIC_CLIENT_ID: demo-client
       RENGA_RUNNER_IMAGE: ${DOCKER_PREFIX}minimal-notebook:${PLATFORM_VERSION}
-      RENGA_REVIEW_DOMAIN: ${PLATFORM_DOMAIN}:8080
+      RENGA_REVIEW_DOMAIN: ${PLATFORM_DOMAIN}
     restart: always
     volumes:
       - ./services/gitlab/runner:/etc/gitlab-runner
@@ -171,14 +179,18 @@ services:
     image: ${DOCKER_PREFIX}renga-ui:${PLATFORM_VERSION}
     restart: always
     ports:
-      - 5000:3000
+      - 3000
     environment:
       GITLAB_URL: ${GITLAB_URL}
-      RENGA_UI_URL: ${RENGA_UI_URL}
+      RENGA_UI_URL: http://${PLATFORM_DOMAIN}
       RENGA_ENDPOINT: ${RENGA_ENDPOINT}
+      KEYCLOAK_URL: http://keycloak.${PLATFORM_DOMAIN}:8080
     labels:
       traefik.enable: "true"
       traefik.frontend.rule: PathPrefix:/
+      traefik.frontend.passHostHeader: "false"
+    networks:
+      - default
 
   reverse-proxy:
     image: traefik
@@ -188,6 +200,7 @@ services:
       --defaultentrypoints=http,https \
       --entrypoints='Name:http Address::80' \
       --entrypoints='Name:https Address::443 TLS:/ssl/test.crt,/ssl/test.key' \
+      --entrypoints='Name:service Address::8080' \
       --docker.exposedbydefault=false
     # FIXME usage of self signed certs --entrypoints='Name:http Address::80 Redirect.EntryPoint:https' \
     ports:

--- a/scripts/wait-for-services.sh
+++ b/scripts/wait-for-services.sh
@@ -22,6 +22,7 @@ docker run \
     --link gitlab \
     --link keycloak \
     --link storage \
-    -e TARGETS=keycloak:8080,gitlab:5080 \
+    --link ui \
+    -e TARGETS=keycloak:8080,gitlab:80,ui:3000 \
     -e TIMEOUT=180 \
     waisbrot/wait


### PR DESCRIPTION
The PR:

* removes references to `localhost`and `docker.for.mac.localhost` and instead uses `renga.local` as the default domain for development 
* the developer must add `renga.local`, `gitlab.renga.local` and `keycloak.renga.local` to `/etc/hosts` in order for the names to resolve. 
* Traefik uses host-based rules instead of prefix-based. 

---

addresses #117 