### PR TITLE
Change keycloak renga realm setting

### DIFF
--- a/services/keycloak/renga-realm.json.tpl
+++ b/services/keycloak/renga-realm.json.tpl
@@ -16,7 +16,7 @@
   "enabled" : true,
   "sslRequired" : "external",
   "registrationAllowed" : true,
-  "registrationEmailAsUsername" : true,
+  "registrationEmailAsUsername" : false,
   "rememberMe" : false,
   "verifyEmail" : false,
   "loginWithEmailAllowed" : true,


### PR DESCRIPTION
Allow the username to differ from the email address in keycloak.