### PR TITLE
jh: launch notebooks with custom image if present

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
         # Add any other gitlab.rb configuration here, each on its own line
     ports:
       - '5022:22'
+      - '5081:5081'
     volumes:
       - gitlab-config:/etc/gitlab
       - gitlab-logs:/var/log/gitlab
@@ -269,16 +270,18 @@ services:
       - 8000
       - 8081
     environment:
-      JUPYTERHUB_CRYPT_KEY: ${JUPYTERHUB_CRYPT_KEY}
-      JUPYTERHUB_NOTEBOOK_DIR: /repo
-      JUPYTERHUB_SPAWNER_CLASS: spawners.RengaDockerSpawner
-      JUPYTERHUB_NOTEBOOK_IMAGE: ${DOCKER_PREFIX}singleuser:${PLATFORM_VERSION}
-      OAUTH2_TOKEN_URL: ${KEYCLOAK_URL}/auth/realms/Renga/protocol/openid-connect/token
-      OAUTH2_AUTHORIZE_URL: ${KEYCLOAK_URL}/auth/realms/Renga/protocol/openid-connect/auth
-      KEYCLOAK_URL: ${KEYCLOAK_URL}
-      GITLAB_HOST: ${GITLAB_URL}
       GITLAB_CLIENT_ID: jupyterhub
       GITLAB_CLIENT_SECRET: no-secret-needed
+      GITLAB_HOST: ${GITLAB_URL}
+      IMAGE_REGISTRY: gitlab.${PLATFORM_DOMAIN}:5081
+      JUPYTERHUB_CRYPT_KEY: ${JUPYTERHUB_CRYPT_KEY}
+      JUPYTERHUB_NOTEBOOK_DIR: /repo
+      JUPYTERHUB_NOTEBOOK_IMAGE: ${DOCKER_PREFIX}singleuser:${PLATFORM_VERSION}
+      JUPYTERHUB_SPAWNER_CLASS: spawners.RengaDockerSpawner
+      KEYCLOAK_URL: ${KEYCLOAK_URL}
+      OAUTH2_AUTHORIZE_URL: ${KEYCLOAK_URL}/auth/realms/Renga/protocol/openid-connect/auth
+      OAUTH2_TOKEN_URL: ${KEYCLOAK_URL}/auth/realms/Renga/protocol/openid-connect/token
+      PLATFORM_DOMAIN: ${PLATFORM_DOMAIN}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./services/jupyterhub/jupyterhub_config.py:/srv/jupyterhub/jupyterhub_config.py:ro

--- a/services/jupyterhub/project_service.py
+++ b/services/jupyterhub/project_service.py
@@ -61,7 +61,8 @@ def authenticated(f):
             # redirect to login url on failed auth
             state = auth.generate_state(next_url=request.path)
             response = make_response(
-                redirect(auth.login_url + '&state=%s' % state))
+                redirect(auth.login_url + '&state=%s' % state)
+            )
             response.set_cookie(auth.state_cookie_name, state)
             return response
 
@@ -80,27 +81,36 @@ def whoami(user):
 
 @app.route(
     SERVICE_PREFIX + '<namespace>/<project>/<commit_sha>/<environment_slug>',
-    methods=['GET'])
+    methods=['GET']
+)
 @app.route(
-    SERVICE_PREFIX + '<namespace>/<project>/<commit_sha>/<environment_slug>/<path:notebook>',
-    methods=['GET'])
+    SERVICE_PREFIX +
+    '<namespace>/<project>/<commit_sha>/<environment_slug>/<path:notebook>',
+    methods=['GET']
+)
 @authenticated
-def launch_notebook(user, namespace, project, commit_sha, environment_slug, notebook=None):
+def launch_notebook(
+    user, namespace, project, commit_sha, environment_slug, notebook=None
+):
     """Launch user server with a given name."""
-    server_name = _server_name(namespace, project, commit_sha, environment_slug)
+    server_name = _server_name(
+        namespace, project, commit_sha, environment_slug
+    )
     headers = {auth.auth_header_name: 'token {0}'.format(auth.api_token)}
+
     # 1. launch using spawner that checks the access
     r = requests.request(
         'POST',
         auth.api_url + '/users/{user[name]}/servers/{server_name}'.format(
-            user=user, server_name=server_name),
+            user=user, server_name=server_name
+        ),
         json={
-            'namespace': namespace,
-            'project': project,
+            'branch': request.args.get('branch', 'master'),
             'commit_sha': commit_sha,
             'environment_slug': environment_slug,
-            'branch': request.args.get('branch', 'master'),
+            'namespace': namespace,
             'notebook': notebook,
+            'project': project,
         },
         headers=headers,
     )
@@ -110,7 +120,8 @@ def launch_notebook(user, namespace, project, commit_sha, environment_slug, note
         abort(r.status_code)
 
     notebook_url = auth.hub_host + '/user/{user[name]}/{server_name}/'.format(
-        user=user, server_name=server_name)
+        user=user, server_name=server_name
+    )
 
     if notebook:
         notebook_url += '/notebooks/{notebook}'.format(notebook=notebook)
@@ -120,18 +131,23 @@ def launch_notebook(user, namespace, project, commit_sha, environment_slug, note
 
 @app.route(
     SERVICE_PREFIX + '<namespace>/<project>/<commit_sha>/<environment_slug>',
-    methods=['DELETE'])
+    methods=['DELETE']
+)
 @authenticated
 def stop_notebook(user, namespace, project, commit_sha, environment_slug):
     """Stop user server with name."""
-    server_name = _server_name(namespace, project, commit_sha, environment_slug)
+    server_name = _server_name(
+        namespace, project, commit_sha, environment_slug
+    )
     headers = {'Authorization': 'token %s' % auth.api_token}
 
     r = requests.request(
         'DELETE',
         auth.api_url + '/users/{user[name]}/servers/{server_name}'.format(
-            user=user, server_name=server_name),
-        headers=headers)
+            user=user, server_name=server_name
+        ),
+        headers=headers
+    )
     return app.response_class(r.content, status=r.status_code)
 
 

--- a/services/jupyterhub/spawners.py
+++ b/services/jupyterhub/spawners.py
@@ -123,7 +123,13 @@ class SpawnerMixin():
         try:
             result = yield super().start(*args, **kwargs)
         except docker.errors.ImageNotFound:
-            self.image = 'rengahub/singleuser:development'
+            self.log.info(
+                'Image {0} not found - using default image.'.
+                format(self.image)
+            )
+            self.image = os.getenv(
+                'JUPYTERHUB_NOTEBOOK_IMAGE', 'jupyter/minimal-notebook'
+            )
             result = yield super().start(*args, **kwargs)
 
         return result

--- a/services/notebook/gitlab_commit_push.py
+++ b/services/notebook/gitlab_commit_push.py
@@ -100,5 +100,8 @@ class GitCommitHandler(IPythonHandler):
             })
 
         self.write({
-            'status': 200,
-            'statusText': 'Notebook was push to branch {}.'.format(gl_branch.name)})
+            'status':
+                200,
+            'statusText':
+                'Notebook was pushed to branch {}.'.format(gl_branch.name)
+        })


### PR DESCRIPTION
Modify the docker spawner to launch notebooks with a custom image. The image name/tag is based on the notebook URL naming scheme. The image has to be built manually for now, see the todo list in #176.

---
addresses #176 