### PR TITLE
Do not show the gitlab login page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ docker-compose-pull: .env
 services/gitlab/%:
 	@mkdir -p $@
 
-.PHONY: enable-gitlab-auto-devops register-gitlab-oauth-applications unregister-gitlab-oauth-applications register-runners unregister-runners demo-admin
+.PHONY: enable-gitlab-auto-devops register-gitlab-oauth-applications unregister-gitlab-oauth-applications register-runners unregister-runners configure-gitlab-login
 enable-gitlab-auto-devops:
 	@docker-compose exec gitlab /opt/gitlab/bin/gitlab-psql \
 		-h /var/opt/gitlab/postgresql -d gitlabhq_production \
@@ -254,6 +254,22 @@ unregister-gitlab-user-token:
 	@$(DOCKER_COMPOSE_ENV) docker-compose exec gitlab /opt/gitlab/bin/gitlab-psql \
 		-h /var/opt/gitlab/postgresql -d gitlabhq_production \
 		-c "DELETE FROM personal_access_tokens WHERE user_id='1' AND name='managed storage token';" > /dev/null 2>&1
+
+# Register an admin user and configure OAuth2 logout URL.
+configure-gitlab-login: .env
+	@curl -X POST -H "Private-token: ${GITLAB_TOKEN}" \
+	  -d '{"username": "demo", \
+	       "email": "demo@datascience.ch", \
+	       "name": "John Doe", \
+	       "extern_uid": "demo", \
+	       "provider": "oauth2_generic", \
+	       "skip_confirmation": true, \
+	       "reset_password": true, \
+	       "admin": true}' \
+	  -H 'Content-Type: application/json' \
+	  ${GITLAB_URL}/api/v4/users > /dev/null 2>&1
+	@curl -X PUT -H "Private-token: ${GITLAB_TOKEN}" \
+	  ${GITLAB_URL}/api/v4/application/settings?after_sign_out_path=${KEYCLOAK_URL}/auth/realms/Renga/protocol/openid-connect/logout?redirect_uri=${GITLAB_URL} > /dev/null 2>&1
 
 register-runners: .env unregister-runners
 ifeq (${GITLAB_RUNNERS_TOKEN},)
@@ -302,20 +318,6 @@ unregister-runners: .env
 			--name $$container-docker || echo ok; \
 	done
 
-# Make an admin demo user
-demo-admin: .env
-	@curl -X POST -H "Private-token: ${GITLAB_TOKEN}" \
-		-d '{"username": "demo", \
-	     "email": "demo@datascience.ch", \
-    	 "name": "John Doe", \
-    	 "extern_uid": "demo", \
-    	 "provider": "oauth2_generic", \
-    	 "skip_confirmation": true, \
-    	 "reset_password": true, \
-    	 "admin": true}' \
-   		-H 'Content-Type: application/json' \
-   		${GITLAB_URL}/api/v4/users > /dev/null 2>&1
-
 # Platform actions
 .PHONY: clean restart start stop test wait wipe
 
@@ -324,7 +326,7 @@ clean: .env
 
 restart: stop start
 
-start: .env docker-network $(GITLAB_DIRS:%=services/gitlab/%) unregister-runners docker-compose-up wait enable-gitlab-auto-devops register-gitlab-oauth-applications register-runners register-gitlab-user-token demo-admin
+start: .env docker-network $(GITLAB_DIRS:%=services/gitlab/%) unregister-runners docker-compose-up wait enable-gitlab-auto-devops register-gitlab-oauth-applications register-runners register-gitlab-user-token configure-gitlab-login
 ifeq (${GITLAB_CLIENT_SECRET}, dummy-secret)
 	@echo
 	@echo "[Warning] You have not defined a GITLAB_CLIENT_SECRET. Using dummy"

--- a/charts/renga/charts/gitlab/templates/_gitlab.rb.tpl
+++ b/charts/renga/charts/gitlab/templates/_gitlab.rb.tpl
@@ -26,6 +26,7 @@ nginx['listen_https'] = false
 ### OmniAuth Settings
 ###! Docs: https://docs.gitlab.com/ce/integration/omniauth.html
 gitlab_rails['omniauth_enabled'] = true
+gitlab_rails['omniauth_auto_sign_in_with_provider'] = 'oauth2_generic'
 gitlab_rails['omniauth_allow_single_sign_on'] = ['oauth2_generic']
 gitlab_rails['omniauth_block_auto_created_users'] = false
 gitlab_rails['omniauth_providers'] = [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,7 @@ services:
         #gitlab_rails['db_adapter'] = 'postgresql'
         #gitlab_rails['db_encoding'] = 'utf8'
         gitlab_rails['omniauth_enabled'] = true
+        gitlab_rails['omniauth_auto_sign_in_with_provider'] = 'oauth2_generic'
         gitlab_rails['omniauth_allow_single_sign_on'] = ['oauth2_generic']
         gitlab_rails['omniauth_block_auto_created_users'] = false
         gitlab_rails['omniauth_providers'] = [

--- a/services/keycloak/renga-realm.json.tpl
+++ b/services/keycloak/renga-realm.json.tpl
@@ -621,7 +621,8 @@
     "clientAuthenticatorType": "client-secret",
     "secret": "{{GITLAB_CLIENT_SECRET}}",
     "redirectUris": [
-      "{{GITLAB_URL}}/users/auth/oauth2_generic/callback"
+      "{{GITLAB_URL}}/users/auth/oauth2_generic/callback",
+      "{{GITLAB_URL}}"
     ],
     "webOrigins": [],
     "notBefore": 0,

--- a/tests/test_renga.py
+++ b/tests/test_renga.py
@@ -28,10 +28,6 @@ def test_renga_login(browser):
     url = os.getenv('RENGA_ENDPOINT', 'http://localhost')
     browser.visit(url)
 
-    assert browser.is_element_present_by_id(
-        'oauth-login-oauth2_generic', wait_time=10)
-    browser.find_by_id('oauth-login-oauth2_generic').click()
-
     assert browser.is_element_present_by_id('username', wait_time=60)
     browser.fill('username', 'demo')
     browser.fill('password', 'demo')


### PR DESCRIPTION
- [x] skip the gitlab login page 
- [x] create an admin/admin user
- [x] fix failing test
- [x] test with docker-compose 
- [ ] test with k8s chart

## Side effects

the `demo` user is made an admin. Could not create an additional `admin` user as this is a protected username in gitlab. 

## Possible bug

Not sure if this is related: cannot log out of gitlab until I delete the `keycloak.renga.build` application data. 

---
closes #185 
