### PR TITLE
Add sudo gitlab token and configure sudo user in init script

### DIFF
--- a/charts/minikube-values.yaml
+++ b/charts/minikube-values.yaml
@@ -22,3 +22,7 @@ jupyterhub:
     state:
       enabled: true
       cryptoKey: 86282f03d9886a64a46ee38f946e9ee27a600df4559584eeb90d0bfbd5a3dc0e
+
+global:
+  gitlab:
+    urlPrefix: /gitlab

--- a/charts/renga/requirements.yaml
+++ b/charts/renga/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: renga-ui
   alias: ui
-  version: "~0.1.0-438e4c5"
+  version: "0.1.0-93b6830"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/charts/renga/templates/configmap.yaml
+++ b/charts/renga/templates/configmap.yaml
@@ -9,20 +9,53 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  init.sh: |-
+  init-gitlab.sh: |-
+    #!/usr/bin/env bash
+
     set -ex
     apt-get update -y
-    apt-get install -y curl
+    apt-get install -y curl jq
 
-    BASE_URL={{ .Values.ui.baseUrl | default (printf "%s://%s" (include "renga-ui.protocol" .) .Values.global.renga.domain) | quote }}
-    GITLAB_URL={{ .Values.ui.gitlabUrl | default (printf "%s://gitlab.%s" (include "renga-ui.protocol" .) .Values.global.renga.domain) | quote }}
+    BASE_URL={{ (printf "http://%s" .Values.global.renga.domain) }}
+    GITLAB_SERVICE_URL={{ template "http" . }}://{{ template "gitlab.fullname" . }}{{ .Values.global.gitlab.urlPrefix }}
+    GITLAB_URL={{ .Values.ui.gitlabUrl }}
+
+    until sleep 1; curl -f -s --connect-timeout 5 ${GITLAB_SERVICE_URL}/help; do
+        echo waiting for gitlab
+    done
 
     psql -v ON_ERROR_STOP=1 <<-EOSQL
         DELETE FROM oauth_applications WHERE uid='renga-ui';
         INSERT INTO oauth_applications (name, uid, scopes, redirect_uri, secret, trusted)
         VALUES ('renga-ui', 'renga-ui', 'api read_user', '$BASE_URL/login/redirect/gitlab', 'no-secret-needed', 'true');
 
-        DELETE FROM personal_access_tokens WHERE user_id='1' AND name='managed storage token';
+        DELETE FROM personal_access_tokens WHERE user_id='1' AND name='managed sudo token';
         INSERT INTO personal_access_tokens ( user_id, token, name, revoked, expires_at, created_at, updated_at, scopes, impersonation)
         VALUES ( '1', '${GITLAB_SUDO_TOKEN}', 'managed sudo token', 'f', NULL, NOW(), NOW(), E'--- \n- api\n- read_user\n- sudo\n- read_registry', 'f');
     EOSQL
+
+
+    # set up the admin user -- first check if the user is there already and grab the ID
+    demo_id=$(curl -s -H "Private-Token: dummy-secret" ${GITLAB_SERVICE_URL}/api/v4/users?username=demo | jq '.[0].id | select(.!=null)')
+
+    if [[ -z "$demo_id" ]]; then
+        method=POST
+    else
+        method=PUT
+    fi
+
+    curl -f -is -X ${method} -H "Private-token: ${GITLAB_SUDO_TOKEN}" \
+        -d  '{"username": "demo",
+        "email": "demo@datascience.ch",
+        "name": "John Doe",
+        "extern_uid": "demo",
+        "provider": "oauth2_generic",
+        "skip_confirmation": "true",
+        "reset_password": "true",
+        "admin": "true"}' \
+        -H "Content-Type: application/json" \
+        ${GITLAB_SERVICE_URL}/api/v4/users/${demo_id}
+
+    # configure the logout redirect
+    curl -f -is -X PUT -H "Private-token: ${GITLAB_SUDO_TOKEN}" \
+      ${GITLAB_SERVICE_URL}/api/v4/application/settings?after_sign_out_path={{ template "http" . }}://{{ .Values.global.renga.domain }}/auth/realms/Renga/protocol/openid-connect/logout?redirect_uri=${GITLAB_URL}

--- a/charts/renga/templates/configmap.yaml
+++ b/charts/renga/templates/configmap.yaml
@@ -21,4 +21,8 @@ data:
         DELETE FROM oauth_applications WHERE uid='renga-ui';
         INSERT INTO oauth_applications (name, uid, scopes, redirect_uri, secret, trusted)
         VALUES ('renga-ui', 'renga-ui', 'api read_user', '$BASE_URL/login/redirect/gitlab', 'no-secret-needed', 'true');
+
+        DELETE FROM personal_access_tokens WHERE user_id='1' AND name='managed storage token';
+        INSERT INTO personal_access_tokens ( user_id, token, name, revoked, expires_at, created_at, updated_at, scopes, impersonation)
+        VALUES ( '1', '${GITLAB_SUDO_TOKEN}', 'managed sudo token', 'f', NULL, NOW(), NOW(), E'--- \n- api\n- read_user\n- sudo\n- read_registry', 'f');
     EOSQL

--- a/charts/renga/templates/post-install-job.yaml
+++ b/charts/renga/templates/post-install-job.yaml
@@ -41,6 +41,11 @@ spec:
               secretKeyRef:
                 name: {{ template "gitlab.fullname" . }}
                 key: postgres-password
+          - name: GITLAB_SUDO_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "renga.fullname" . }}
+                key: gitlab-sudo-token
       volumes:
         - name: init
           configMap:

--- a/charts/renga/templates/post-install-job.yaml
+++ b/charts/renga/templates/post-install-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}"
+  name: "{{ .Release.Name }}-post-install"
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -22,9 +22,9 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        - name: configure-gitlab-ui-token
+        - name: configure-gitlab
           image: "postgres:9.6"
-          command: ["/bin/sh", "/scripts/init.sh"]
+          command: ["/bin/bash", "/scripts/init-gitlab.sh"]
           volumeMounts:
             - name: init
               mountPath: /scripts

--- a/charts/renga/templates/secrets.yaml
+++ b/charts/renga/templates/secrets.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "renga.fullname" . }}
+  labels:
+    app: {{ template "renga.name" . }}
+    chart: {{ template "renga.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+{{- if .Values.global.gitlab.sudoToken }}
+  gitlab-sudo-token: {{ .Values.global.gitlab.sudoToken | b64enc | quote }}
+{{- else }}
+  gitlab-sudo-token: {{ randAlphaNum 10 | b64enc | quote }}
+{{- end }}

--- a/charts/renga/values.yaml
+++ b/charts/renga/values.yaml
@@ -16,6 +16,8 @@ global:
     postgresUser: gitlab
     ## Postgres password for the gitlab database
     postgresPassword: gitlab
+    ## Sudo token for sudo API requests
+    sudoToken: dummy-secret
   keycloak:
     ## Name of the postgres database to be used by Keycloak
     postgresDatabase: keycloak

--- a/charts/renga/values.yaml
+++ b/charts/renga/values.yaml
@@ -18,6 +18,9 @@ global:
     postgresPassword: gitlab
     ## Sudo token for sudo API requests
     sudoToken: dummy-secret
+    ## URL prefix for gitlab
+    # urlPrefix: /
+
   keycloak:
     ## Name of the postgres database to be used by Keycloak
     postgresDatabase: keycloak


### PR DESCRIPTION
This adds the sudo token needed for certain API actions and creates the sudo user in gitlab. 

This is critical if we want to have admin access in gitlab if we only use keycloak for login. 